### PR TITLE
Update FBSnapshotTestCase

### DIFF
--- a/Bootstrap/Bootstrap.xcodeproj/project.pbxproj
+++ b/Bootstrap/Bootstrap.xcodeproj/project.pbxproj
@@ -12,8 +12,8 @@
 		5E28C2B71993C6FF0066DB4D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5E28C2B51993C6FF0066DB4D /* Main.storyboard */; };
 		5E28C2B91993C6FF0066DB4D /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5E28C2B81993C6FF0066DB4D /* Images.xcassets */; };
 		5EDEF1DE1A1E5780004D7BAB /* BootstrapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EDEF1DD1A1E5780004D7BAB /* BootstrapTests.swift */; };
-		6295B4CC832901BBDBA138F6 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D26F915EABE9C6406B92568 /* libPods.a */; };
 		75349360E61893E348863C17 /* Pods_BootstrapTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A6AC46E04FD3DD50EBAB6A43 /* Pods_BootstrapTests.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		F6BB19F9C9EF23ACD36A4305 /* Pods.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A57DFE7C77534A99563B1C8B /* Pods.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -27,7 +27,6 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		4D26F915EABE9C6406B92568 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		5E28C2AC1993C6FE0066DB4D /* Bootstrap.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Bootstrap.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5E28C2B01993C6FE0066DB4D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		5E28C2B11993C6FE0066DB4D /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -42,6 +41,7 @@
 		874CB72BE021E4810FABCDB6 /* Pods-BootstrapTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BootstrapTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-BootstrapTests/Pods-BootstrapTests.debug.xcconfig"; sourceTree = "<group>"; };
 		8C039C0BD01E675440DB58A4 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
 		9B19CE442882E1603E66F608 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
+		A57DFE7C77534A99563B1C8B /* Pods.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A6AC46E04FD3DD50EBAB6A43 /* Pods_BootstrapTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_BootstrapTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -50,7 +50,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6295B4CC832901BBDBA138F6 /* libPods.a in Frameworks */,
+				F6BB19F9C9EF23ACD36A4305 /* Pods.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -138,7 +138,7 @@
 			children = (
 				5E28C2F31993CBBC0066DB4D /* QuartzCore.framework */,
 				A6AC46E04FD3DD50EBAB6A43 /* Pods_BootstrapTests.framework */,
-				4D26F915EABE9C6406B92568 /* libPods.a */,
+				A57DFE7C77534A99563B1C8B /* Pods.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -155,6 +155,7 @@
 				5E28C2A91993C6FE0066DB4D /* Frameworks */,
 				5E28C2AA1993C6FE0066DB4D /* Resources */,
 				BFCF074242459CF3CB57FEBF /* Copy Pods Resources */,
+				83C316B952998E0CF0B90255 /* Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -271,6 +272,21 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		83C316B952998E0CF0B90255 /* Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		B4D253BBED47099132F6C312 /* Embed Pods Frameworks */ = {

--- a/Bootstrap/Bootstrap/AppDelegate.swift
+++ b/Bootstrap/Bootstrap/AppDelegate.swift
@@ -14,30 +14,30 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
 
-    func application(application: UIApplication!, didFinishLaunchingWithOptions launchOptions: NSDictionary!) -> Bool {
+    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }
 
-    func applicationWillResignActive(application: UIApplication!) {
+    func applicationWillResignActive(application: UIApplication) {
         // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
         // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
     }
 
-    func applicationDidEnterBackground(application: UIApplication!) {
+    func applicationDidEnterBackground(application: UIApplication) {
         // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
         // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
     }
 
-    func applicationWillEnterForeground(application: UIApplication!) {
+    func applicationWillEnterForeground(application: UIApplication) {
         // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
     }
 
-    func applicationDidBecomeActive(application: UIApplication!) {
+    func applicationDidBecomeActive(application: UIApplication) {
         // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
     }
 
-    func applicationWillTerminate(application: UIApplication!) {
+    func applicationWillTerminate(application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
 

--- a/Bootstrap/Podfile
+++ b/Bootstrap/Podfile
@@ -1,6 +1,8 @@
 source 'https://github.com/CocoaPods/Specs.git'
 source 'https://github.com/artsy/Specs.git'
 
+use_frameworks!
+
 # Need one pod
 pod 'Artsy+UIColors'
 

--- a/Bootstrap/Podfile.lock
+++ b/Bootstrap/Podfile.lock
@@ -2,13 +2,13 @@ PODS:
   - Artsy+UIColors (1.0.0):
     - EDColor (~> 0.4)
   - EDColor (0.4.0)
-  - FBSnapshotTestCase (1.5)
-  - Nimble (0.3.0)
+  - FBSnapshotTestCase (1.7)
+  - Nimble (0.4.2)
   - Nimble-Snapshots (0.3):
-    - FBSnapshotTestCase (~> 1.5)
+    - FBSnapshotTestCase (~> 1.7)
     - Nimble (~> 0.3)
     - Quick (~> 0.2)
-  - Quick (0.2.2)
+  - Quick (0.3.1)
 
 DEPENDENCIES:
   - Artsy+UIColors
@@ -16,14 +16,14 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   Nimble-Snapshots:
-    :path: ../
+    :path: "../"
 
 SPEC CHECKSUMS:
   Artsy+UIColors: d1d5e084a0e542d310c507acb5446bae6a322241
-  EDColor: bcdb8600b7a456f4408ce1d7e7fc001588919254
-  FBSnapshotTestCase: e2914fbaabccea1dcc773d6a16b1c24540642488
-  Nimble: a4d9d978129e83d73e33b7d8bce57443bd556068
-  Nimble-Snapshots: 727fb13569953b96247053978125c528ea8c492c
-  Quick: 7b89ff625e72ef931c2a9ef2f25ac3a9d2457763
+  EDColor: 89d19a013279a5604d61650721c15f20fefaaf00
+  FBSnapshotTestCase: 1eea5145c1f2fa907812ab92e1d6063a8d809b4e
+  Nimble: 49b7a7da8919f42823d37c6d68cc6d15a7009f32
+  Nimble-Snapshots: 1fcece2456f86385f6aed5ce54189b687e95af96
+  Quick: 824572d3d198d51e52cf4aa722cebf7e59952a35
 
-COCOAPODS: 0.36.0.beta.1
+COCOAPODS: 0.36.3

--- a/HaveValidSnapshot.swift
+++ b/HaveValidSnapshot.swift
@@ -40,7 +40,6 @@ extension UIView : Snapshotable {
         var snapshotController: FBSnapshotTestController = FBSnapshotTestController(testName: _testFileName())
         snapshotController.recordMode = record
         snapshotController.referenceImagesDirectory = referenceDirectory
-        snapshotController.renderAsLayer = true
 
         assert(snapshotController.referenceImagesDirectory != nil, "Missing value for referenceImagesDirectory - Call FBSnapshotTest.setReferenceImagesDirectory(FB_REFERENCE_IMAGE_DIR)")
 
@@ -71,7 +70,7 @@ func _getDefaultReferenceDirectory(sourceFileName: String) -> String {
 
     assert(result != nil, "Could not infer reference image folder – You should provide a reference dir using FBSnapshotTest.setReferenceImagesDirectory(FB_REFERENCE_IMAGE_DIR)")
 
-    return result!
+    return result! as String
 }
 
 func _testFileName() -> String {

--- a/Nimble-Snapshots.podspec
+++ b/Nimble-Snapshots.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.source_files  = "HaveValidSnapshot.swift", "PrettySyntax.swift"
   s.requires_arc = true
   s.frameworks  = "Foundation", "XCTest"
-  s.dependency "FBSnapshotTestCase", "~>1.5"
+  s.dependency "FBSnapshotTestCase", "~>1.7"
   s.dependency "Nimble", "~> 0.3"
   s.dependency "Quick", "~> 0.2"
 end

--- a/Nimble-Snapshots.podspec
+++ b/Nimble-Snapshots.podspec
@@ -15,6 +15,6 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.frameworks  = "Foundation", "XCTest"
   s.dependency "FBSnapshotTestCase", "~>1.7"
-  s.dependency "Nimble", "~> 0.3"
-  s.dependency "Quick", "~> 0.2"
+  s.dependency "Nimble", "~> 0.4"
+  s.dependency "Quick", "~> 0.3"
 end


### PR DESCRIPTION
Hi.
I've made a couple of fixes to the issues mentioned in Issue #23. The spec now requires `1.7`, I hope it's ok. 
The major breaking change was `renderAsLayer` which now defaults to `true`, so it's safe to just remove the line:
```swift
snapshotController.renderAsLayer = true
```

Cheers!