### PR TITLE
Update for Swift 2.0 and Xcode 7

### DIFF
--- a/Bootstrap/Bootstrap.xcodeproj/project.pbxproj
+++ b/Bootstrap/Bootstrap.xcodeproj/project.pbxproj
@@ -193,6 +193,7 @@
 		5E28C2A41993C6FE0066DB4D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftUpdateCheck = 0700;
 				LastUpgradeCheck = 0600;
 				ORGANIZATIONNAME = Artsy;
 				TargetAttributes = {

--- a/Bootstrap/Podfile.lock
+++ b/Bootstrap/Podfile.lock
@@ -2,13 +2,13 @@ PODS:
   - Artsy+UIColors (1.0.0):
     - EDColor (~> 0.4)
   - EDColor (0.4.0)
-  - FBSnapshotTestCase (1.7)
-  - Nimble (0.4.2)
-  - Nimble-Snapshots (0.3):
+  - FBSnapshotTestCase (1.8.1)
+  - Nimble (2.0.0-rc.1)
+  - Nimble-Snapshots (0.4.0):
     - FBSnapshotTestCase (~> 1.7)
-    - Nimble (~> 0.3)
-    - Quick (~> 0.2)
-  - Quick (0.3.1)
+    - Nimble (~> 2.0.0-rc.1)
+    - Quick (~> 0.4.0)
+  - Quick (0.4.0)
 
 DEPENDENCIES:
   - Artsy+UIColors
@@ -16,14 +16,14 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   Nimble-Snapshots:
-    :path: "../"
+    :path: ../
 
 SPEC CHECKSUMS:
   Artsy+UIColors: d1d5e084a0e542d310c507acb5446bae6a322241
   EDColor: 89d19a013279a5604d61650721c15f20fefaaf00
-  FBSnapshotTestCase: 1eea5145c1f2fa907812ab92e1d6063a8d809b4e
-  Nimble: 49b7a7da8919f42823d37c6d68cc6d15a7009f32
-  Nimble-Snapshots: 1fcece2456f86385f6aed5ce54189b687e95af96
-  Quick: 824572d3d198d51e52cf4aa722cebf7e59952a35
+  FBSnapshotTestCase: 3dc3899168747a0319c5278f5b3445c13a6532dd
+  Nimble: 9572458605e65c9fc5a56754ab19a970f6ab5a88
+  Nimble-Snapshots: ca3fbf1e9e85cc5c4fdb4424476afd7c554d56bd
+  Quick: 2286bfff349102670c6d2dafd0d2cefab42f5f0b
 
-COCOAPODS: 0.36.3
+COCOAPODS: 0.37.2

--- a/HaveValidSnapshot.swift
+++ b/HaveValidSnapshot.swift
@@ -42,8 +42,13 @@ extension UIView : Snapshotable {
         snapshotController.referenceImagesDirectory = referenceDirectory
 
         assert(snapshotController.referenceImagesDirectory != nil, "Missing value for referenceImagesDirectory - Call FBSnapshotTest.setReferenceImagesDirectory(FB_REFERENCE_IMAGE_DIR)")
-
-        return snapshotController.compareSnapshotOfView(instance.snapshotObject, selector: Selector(snapshot), identifier: nil, error: nil)
+        do {
+            try snapshotController.compareSnapshotOfView(instance.snapshotObject, selector: Selector(snapshot), identifier: nil)
+        }
+        catch {
+            return false;
+        }
+        return true;
     }
 }
 
@@ -138,10 +143,10 @@ public func haveValidSnapshot() -> MatcherFunc<Snapshotable> {
     return MatcherFunc { actualExpression, failureMessage in
         let testFileLocation = actualExpression.location.file
         if (switchChecksWithRecords) {
-            return _recordSnapshot(nil, actualExpression, failureMessage)
+            return _recordSnapshot(nil, actualExpression: actualExpression, failureMessage: failureMessage)
         }
 
-        return _performSnapshotTest(nil, actualExpression, failureMessage)
+        return _performSnapshotTest(nil, actualExpression: actualExpression, failureMessage: failureMessage)
     }
 }
 
@@ -149,10 +154,10 @@ public func haveValidSnapshot(named name: String) -> MatcherFunc<Snapshotable> {
     return MatcherFunc { actualExpression, failureMessage in
         let testFileLocation = actualExpression.location.file
         if (switchChecksWithRecords) {
-            return _recordSnapshot(name, actualExpression, failureMessage)
+            return _recordSnapshot(name, actualExpression: actualExpression, failureMessage: failureMessage)
         }
 
-        return _performSnapshotTest(name, actualExpression, failureMessage)
+        return _performSnapshotTest(name, actualExpression: actualExpression, failureMessage: failureMessage)
     }
 }
 
@@ -160,12 +165,12 @@ public func recordSnapshot() -> MatcherFunc<Snapshotable> {
     return MatcherFunc { actualExpression, failureMessage in
         let testFileLocation = actualExpression.location.file
 
-        return _recordSnapshot(nil, actualExpression, failureMessage)
+        return _recordSnapshot(nil, actualExpression: actualExpression, failureMessage: failureMessage)
     }
 }
 
 public func recordSnapshot(named name: String) -> MatcherFunc<Snapshotable> {
     return MatcherFunc { actualExpression, failureMessage in
-        return _recordSnapshot(name, actualExpression, failureMessage)
+        return _recordSnapshot(name, actualExpression: actualExpression, failureMessage: failureMessage)
     }
 }

--- a/Nimble-Snapshots.podspec
+++ b/Nimble-Snapshots.podspec
@@ -15,6 +15,6 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.frameworks  = "Foundation", "XCTest"
   s.dependency "FBSnapshotTestCase", "~>1.7"
-  s.dependency "Nimble", "~> 0.4"
-  s.dependency "Quick", "~> 0.3"
+  s.dependency "Nimble", "~> 2.0.0-rc.1"
+  s.dependency "Quick", "~> 0.4.0"
 end


### PR DESCRIPTION
Hello,

I tried to send this PR against a swift-2.0 branch but it wouldn't let me send the PR against a branch that doesn't exist.

Per Quick/Quick#322, they're keeping swift-2.0 out of their master branch until it is out of beta, so it may make sense to do the same. I can send you a new PR if you want to create the swift-2.0 branch from master.

I upgraded to the latest Nimble and Quick and fixed the compiler errors. (But not the warnings.) 

The BootstrapTests seem to pass. I didn't add any new tests.

If you wanted to match Nimble and Quick, we could get this merged into a swift-2.0 branch, make that the default branch for this repository, and then release this to CocoaPods as Nimble-Snapshots 0.5.0. Then we could update CocoaPods/pod-template#117.