### PR TITLE
I made some changes, you want em!? :-)

### DIFF
--- a/HaveValidSnapshot.swift
+++ b/HaveValidSnapshot.swift
@@ -101,9 +101,9 @@ func _testFileName() -> String {
     return sanitizedName
 }
 
-func _sanitizedTestName() -> String {
+func _sanitizedTestName(name: String?) -> String {
     let quickExample = FBSnapshotTest.sharedInstance.currentExampleMetadata
-    var filename = quickExample!.example.name
+    var filename = name ?? quickExample!.example.name
     filename = filename.stringByReplacingOccurrencesOfString("root example group, ", withString: "")
     let characterSet = NSCharacterSet(charactersInString: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_")
     let components: NSArray = filename.componentsSeparatedByCharactersInSet(characterSet.invertedSet)
@@ -122,7 +122,7 @@ func _performSnapshotTest(name: String?, actualExpression: Expression<Snapshotab
     let instance = try! actualExpression.evaluate()!
     let testFileLocation = actualExpression.location.file
     let referenceImageDirectory = _getDefaultReferenceDirectory(testFileLocation)
-    let snapshotName = name ?? _sanitizedTestName()
+    let snapshotName = _sanitizedTestName(name)
 
     let result = FBSnapshotTest.compareSnapshot(instance, snapshot: snapshotName, record: false, referenceDirectory: referenceImageDirectory)
 
@@ -139,7 +139,7 @@ func _recordSnapshot(name: String?, actualExpression: Expression<Snapshotable>, 
     let instance = try! actualExpression.evaluate()!
     let testFileLocation = actualExpression.location.file
     let referenceImageDirectory = _getDefaultReferenceDirectory(testFileLocation)
-    let snapshotName = name ?? _sanitizedTestName()
+    let snapshotName = _sanitizedTestName(name)
 
     _clearFailureMessage(failureMessage)
 

--- a/HaveValidSnapshot.swift
+++ b/HaveValidSnapshot.swift
@@ -55,6 +55,11 @@ extension UIView : Snapshotable {
     }
 }
 
+var testFolderSuffixes = ["tests", "specs"]
+public func setNimbleTestFolder(testFolder: String) {
+    testFolderSuffixes = [testFolder.lowercaseString]
+}
+
 func _getDefaultReferenceDirectory(sourceFileName: String) -> String {
     if let globalReference = FBSnapshotTest.sharedInstance.referenceImagesDirectory {
         return globalReference
@@ -67,8 +72,15 @@ func _getDefaultReferenceDirectory(sourceFileName: String) -> String {
 
     let pathComponents: NSArray = (sourceFileName as NSString).pathComponents
     for folder in pathComponents {
+        var found = false
+        for suffix in testFolderSuffixes {
+            if (folder.lowercaseString as NSString).hasSuffix(suffix) {
+                found = true
+                break
+            }
+        }
 
-        if (folder.lowercaseString as NSString).hasSuffix("tests") {
+        if found {
             let currentIndex = pathComponents.indexOfObject(folder) + 1
             let folderPathComponents: NSArray = pathComponents.subarrayWithRange(NSMakeRange(0, currentIndex))
             let folderPath = folderPathComponents.componentsJoinedByString("/")

--- a/HaveValidSnapshot.swift
+++ b/HaveValidSnapshot.swift
@@ -128,7 +128,12 @@ func _performSnapshotTest(name: String?, actualExpression: Expression<Snapshotab
 
     if !result {
         _clearFailureMessage(failureMessage)
-        failureMessage.actualValue = "expected a matching snapshot in \(name)"
+        if let name = name {
+            failureMessage.actualValue = "expected a matching snapshot in \(name)"
+        }
+        else {
+            failureMessage.actualValue = "expected a matching snapshot"
+        }
     }
 
     return result

--- a/HaveValidSnapshot.swift
+++ b/HaveValidSnapshot.swift
@@ -57,7 +57,7 @@ extension UIView : Snapshotable {
 
 var testFolderSuffixes = ["tests", "specs"]
 public func setNimbleTestFolder(testFolder: String) {
-    testFolderSuffixes = [testFolder.lowercaseString]
+    testFolderSuffixes = [testFolder]
 }
 
 func _getDefaultReferenceDirectory(sourceFileName: String) -> String {
@@ -74,7 +74,7 @@ func _getDefaultReferenceDirectory(sourceFileName: String) -> String {
     for folder in pathComponents {
         var found = false
         for suffix in testFolderSuffixes {
-            if (folder.lowercaseString as NSString).hasSuffix(suffix) {
+            if (folder.lowercaseString as NSString).hasSuffix(suffix.lowercaseString) {
                 found = true
                 break
             }

--- a/HaveValidSnapshot.swift
+++ b/HaveValidSnapshot.swift
@@ -154,17 +154,7 @@ func _recordSnapshot(name: String?, actualExpression: Expression<Snapshotable>, 
 
 internal var switchChecksWithRecords = false
 
-public func haveValidSnapshot() -> MatcherFunc<Snapshotable> {
-    return MatcherFunc { actualExpression, failureMessage in
-        if (switchChecksWithRecords) {
-            return _recordSnapshot(nil, actualExpression: actualExpression, failureMessage: failureMessage)
-        }
-
-        return _performSnapshotTest(nil, actualExpression: actualExpression, failureMessage: failureMessage)
-    }
-}
-
-public func haveValidSnapshot(named name: String) -> MatcherFunc<Snapshotable> {
+public func haveValidSnapshot(named name: String? = nil) -> MatcherFunc<Snapshotable> {
     return MatcherFunc { actualExpression, failureMessage in
         if (switchChecksWithRecords) {
             return _recordSnapshot(name, actualExpression: actualExpression, failureMessage: failureMessage)
@@ -174,13 +164,7 @@ public func haveValidSnapshot(named name: String) -> MatcherFunc<Snapshotable> {
     }
 }
 
-public func recordSnapshot() -> MatcherFunc<Snapshotable> {
-    return MatcherFunc { actualExpression, failureMessage in
-        return _recordSnapshot(nil, actualExpression: actualExpression, failureMessage: failureMessage)
-    }
-}
-
-public func recordSnapshot(named name: String) -> MatcherFunc<Snapshotable> {
+public func recordSnapshot(named name: String? = nil) -> MatcherFunc<Snapshotable> {
     return MatcherFunc { actualExpression, failureMessage in
         return _recordSnapshot(name, actualExpression: actualExpression, failureMessage: failureMessage)
     }


### PR DESCRIPTION
No changes, actually, just compatibility related things.  For instance, we use a `Specs` folder instead of `BlaTests`.  So this supports either (`*Tests` or `*Specs`), or you can set it to a custom suffix.

Btw, the specs issue a warning about calling `FBSnapshotTest.setReferenceImagesDirectory`, but that is an internal method.  It's also not clear to me how to call it; I tried `FBSnapshotTest.setReferenceImagesDirectory("Specs")` and that did NOT work.  So I guess it needs a full path.

I removed the two methods and replaced them with just one, relying on a default `nil` value instead.  This seemed so obvious that I'm worried that I'm reintroducing a regression... but I'm using the `name:-less` version and it works great, so I'll submit it here for debate.