### PR TITLE
Fix failure message by removing the “, got” prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Nimble-Snapshots
 
+* Improved failure messages by removing the prefix ", got" - @MP0w
+
 ## 4.3.0
 
 * Adds support for testing dynamic type - @marcelofabri

--- a/HaveValidSnapshot.swift
+++ b/HaveValidSnapshot.swift
@@ -155,7 +155,7 @@ func _getTolerance() -> CGFloat {
 }
 
 func _clearFailureMessage(_ failureMessage: FailureMessage) {
-    failureMessage.actualValue = ""
+    failureMessage.actualValue = nil
     failureMessage.expected = ""
     failureMessage.postfixMessage = ""
     failureMessage.to = ""
@@ -172,7 +172,7 @@ func _performSnapshotTest(_ name: String?, isDeviceAgnostic: Bool=false, usesDra
 
     if !result {
         _clearFailureMessage(failureMessage)
-        failureMessage.actualValue = "expected a matching snapshot in \(snapshotName)"
+        failureMessage.expected = "expected a matching snapshot in \(snapshotName)"
     }
 
     return result
@@ -188,9 +188,9 @@ func _recordSnapshot(_ name: String?, isDeviceAgnostic: Bool=false, usesDrawRect
     _clearFailureMessage(failureMessage)
 
     if FBSnapshotTest.compareSnapshot(instance, isDeviceAgnostic: isDeviceAgnostic, usesDrawRect: usesDrawRect, snapshot: snapshotName, record: true, referenceDirectory: referenceImageDirectory, tolerance: tolerance) {
-        failureMessage.actualValue = "snapshot \(name ?? snapshotName) successfully recorded, replace recordSnapshot with a check"
+        failureMessage.expected = "snapshot \(name ?? snapshotName) successfully recorded, replace recordSnapshot with a check"
     } else {
-        failureMessage.actualValue = "expected to record a snapshot in \(name)"
+        failureMessage.expected = "expected to record a snapshot in \(name)"
     }
 
     return false


### PR DESCRIPTION
Fixes the failure messages, they were all prefixed by ", got" (e.g. ", got expected to record a snapshot in...")
I guess something recently changed in Nimble? `FailureMessage` breaking change?