### PR TITLE
Support FailureDiffs without configuration

### DIFF
--- a/HaveValidSnapshot.swift
+++ b/HaveValidSnapshot.swift
@@ -99,6 +99,8 @@ func getDefaultReferenceDirectory(_ sourceFileName: String) -> String {
     let folderPathComponents = pathComponents.subarray(with: NSRange(location: 0, length: currentIndex)) as NSArray
     let folderPath = folderPathComponents.componentsJoined(by: "/")
 
+    setDefaultFailureDiffsDirectory(testTargetFolderPath: folderPath)
+
     return folderPath + "/ReferenceImages"
 }
 
@@ -109,6 +111,10 @@ private func parseFilename(filename: String) -> String {
     let sanitizedName = nsName.lastPathComponent.replacingOccurrences(of: type, with: "")
 
     return sanitizedName
+}
+
+func setDefaultFailureDiffsDirectory(testTargetFolderPath: String) {
+    setenv("IMAGE_DIFF_DIR", "\(testTargetFolderPath)/FailureDiffs", 0)
 }
 
 func sanitizedTestName(_ name: String?) -> String {

--- a/README.md
+++ b/README.md
@@ -178,3 +178,14 @@ implement the `ViewResizer` protocol and resize yourself.
 The custom behavior can be used to record the views too.
 
 For more info on usage, check the [dynamic sizes tests](Bootstrap/BootstrapTests/DynamicSizeTests.swift).
+
+## A note about test failures artifacts
+
+By default Nimble-Snapshot will place test failures image diffs in a folder right next to `ReferenceImages`. It is strongly recommended that you don't commit those files to your source repo.
+
+Add this to your `.gitignore`:
+
+```
+# Nimble-Snapshot
+FailureDiffs
+```


### PR DESCRIPTION
This took an unexpected turn. There's a nice interface defined for the
reference folder:
https://github.com/facebook/ios-snapshot-test-case/blob/master/FBSnapshotTestCase/FBSnapshotTestController.h#L72

That's not the case for the failure diffs folder. I had to get creative
so I used the setenv in order to give this failure diffs folder mapping
by default. See here to know how it's used in the FBSnapshotTestCase
project:
https://github.com/facebook/ios-snapshot-test-case/blob/master/FBSnapshotTestCase/FBSnapshotTestController.m#L266-L268

With all that said I'm still opening a PR cause I said I would and it was pretty straightforward but I won't feel bad if this gets rejected given the implementation I am submitting. I could take a further step and propose a change in `FBSnapshotTestCase` but I am not sure if I want to give that a shot.

Ref: https://github.com/ashfurrow/Nimble-Snapshots/issues/68