### PR TITLE
Convert Nimble_Snapshots project to Swift 3

### DIFF
--- a/Nimble_Snapshots.xcodeproj/project.pbxproj
+++ b/Nimble_Snapshots.xcodeproj/project.pbxproj
@@ -116,6 +116,7 @@
 				TargetAttributes = {
 					095B476C1D4773F000880922 = {
 						CreatedOnToolsVersion = 7.3.1;
+						LastSwiftMigration = 0820;
 					};
 				};
 			};
@@ -273,6 +274,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -297,6 +299,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.wallapop.Nimble-Snapshots";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Contrary to what README says, the project cannot be installed with Carthage for Swift 3 (Xcode 8.2):

```
/usr/bin/xcrun xcodebuild -project /Users/dawiddr/Documents/Workspace/office-timer/OfficeTimer/Carthage/Checkouts/Nimble-Snapshots/Nimble_Snapshots.xcodeproj -scheme Nimble_Snapshots -configuration Release -sdk iphoneos -toolchain com.apple.dt.toolchain.Swift_3_0 ONLY_ACTIVE_ARCH=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= CARTHAGE=YES clean buildBuild settings from command line:
    CARTHAGE = YES
    CODE_SIGN_IDENTITY = 
    CODE_SIGNING_REQUIRED = NO
    ONLY_ACTIVE_ARCH = NO
    SDKROOT = iphoneos10.2
    TOOLCHAINS = com.apple.dt.toolchain.Swift_3_0

=== CLEAN TARGET Nimble_Snapshots OF PROJECT Nimble_Snapshots WITH CONFIGURATION Release ===

Check dependencies
“Use Legacy Swift Language Version” (SWIFT_VERSION) is required to be configured correctly for targets which use Swift. Use the [Edit > Convert > To Current Swift Syntax…] menu to choose a Swift version or use the Build Settings editor to configure the build setting directly.
“Use Legacy Swift Language Version” (SWIFT_VERSION) is required to be configured correctly for targets which use Swift. Use the [Edit > Convert > To Current Swift Syntax…] menu to choose a Swift version or use the Build Settings editor to configure the build setting directly.

=== BUILD TARGET Nimble_Snapshots OF PROJECT Nimble_Snapshots WITH CONFIGURATION Release ===

Check dependencies
“Use Legacy Swift Language Version” (SWIFT_VERSION) is required to be configured correctly for targets which use Swift. Use the [Edit > Convert > To Current Swift Syntax…] menu to choose a Swift version or use the Build Settings editor to configure the build setting directly.
“Use Legacy Swift Language Version” (SWIFT_VERSION) is required to be configured correctly for targets which use Swift. Use the [Edit > Convert > To Current Swift Syntax…] menu to choose a Swift version or use the Build Settings editor to configure the build setting directly.
```

This pull request fixes it by setting Swift version to 3.
