### PR TITLE
Making device agnostic flag available for dynamic size snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master
 
 * Drops support for Swift 2.3 - @marcelofabri
+* Adds device agnostic support for testing dynamic sizes - @fsaragoca
 
 ## 4.4.2
 

--- a/DynamicSize/DynamicSizeSnapshot.swift
+++ b/DynamicSize/DynamicSizeSnapshot.swift
@@ -135,9 +135,9 @@ public func snapshot(_ name: String? = nil, sizes: [String: CGSize], resizeMode:
     return DynamicSizeSnapshot(name: name, record: false, sizes: sizes, resizeMode: resizeMode)
 }
 
-public func haveValidDynamicSizeSnapshot(named name: String? = nil, sizes: [String: CGSize], usesDrawRect: Bool = false, tolerance: CGFloat? = nil, resizeMode: ResizeMode = .frame) -> MatcherFunc<Snapshotable> {
+public func haveValidDynamicSizeSnapshot(named name: String? = nil, sizes: [String: CGSize], isDeviceAgnostic: Bool = false, usesDrawRect: Bool = false, tolerance: CGFloat? = nil, resizeMode: ResizeMode = .frame) -> MatcherFunc<Snapshotable> {
     return MatcherFunc { actualExpression, failureMessage in
-        return performDynamicSizeSnapshotTest(name, sizes: sizes, usesDrawRect: usesDrawRect, actualExpression: actualExpression, failureMessage: failureMessage, tolerance: tolerance, isRecord: false, resizeMode: resizeMode)
+        return performDynamicSizeSnapshotTest(name, sizes: sizes, isDeviceAgnostic: isDeviceAgnostic, usesDrawRect: usesDrawRect, actualExpression: actualExpression, failureMessage: failureMessage, tolerance: tolerance, isRecord: false, resizeMode: resizeMode)
     }
 }
 
@@ -181,9 +181,9 @@ public func recordSnapshot(_ name: String? = nil, sizes: [String: CGSize], resiz
     return DynamicSizeSnapshot(name: name, record: true, sizes: sizes, resizeMode: resizeMode)
 }
 
-public func recordDynamicSizeSnapshot(named name: String? = nil, sizes: [String: CGSize], usesDrawRect: Bool = false, resizeMode: ResizeMode = .frame) -> MatcherFunc<Snapshotable> {
+public func recordDynamicSizeSnapshot(named name: String? = nil, sizes: [String: CGSize], isDeviceAgnostic: Bool = false, usesDrawRect: Bool = false, resizeMode: ResizeMode = .frame) -> MatcherFunc<Snapshotable> {
     return MatcherFunc { actualExpression, failureMessage in
-        return performDynamicSizeSnapshotTest(name, sizes: sizes, usesDrawRect: usesDrawRect, actualExpression: actualExpression, failureMessage: failureMessage, isRecord: true, resizeMode: resizeMode)
+        return performDynamicSizeSnapshotTest(name, sizes: sizes, isDeviceAgnostic: isDeviceAgnostic, usesDrawRect: usesDrawRect, actualExpression: actualExpression, failureMessage: failureMessage, isRecord: true, resizeMode: resizeMode)
     }
 }
 


### PR DESCRIPTION
`isDeviceAgnostic` flag was implemented in the private function `performDynamicSizeSnapshotTest`, but is not public available in the two public functions for validating and recording snapshots with dynamic size.

The only documentation I found is a link to [DynamicSizeTests.swift](https://github.com/ashfurrow/Nimble-Snapshots/blob/74da09dc9957f2dcf522aec45d6ed883d643cf56/Bootstrap/BootstrapTests/DynamicSizeTests.swift) in [README](https://github.com/ashfurrow/Nimble-Snapshots/blob/master/README.md), however that file is being removed by @marcelofabri in #80, so I don't think I need to change anything else. Please correct me if I'm wrong :)