### PR TITLE
Updated dependencies: Quick (v.6.1.0) and Nimble (v.1.1.0). Swift 3.1 warning.

### DIFF
--- a/Bootstrap/Podfile
+++ b/Bootstrap/Podfile
@@ -5,7 +5,7 @@ pod 'Forgeries'
 
 target 'BootstrapTests' do
   pod 'Quick', '~> 1.1.0'
-  pod 'Nimble', '~> 6.0.1'
+  pod 'Nimble', '~> 6.1.0'
   pod 'FBSnapshotTestCase', git: 'https://github.com/facebook/ios-snapshot-test-case.git'
 
   pod 'Nimble-Snapshots/DynamicType', :path => "../"

--- a/Bootstrap/Podfile.lock
+++ b/Bootstrap/Podfile.lock
@@ -7,7 +7,7 @@ PODS:
   - Forgeries (1.0.0):
     - Forgeries/Core (= 1.0.0)
   - Forgeries/Core (1.0.0)
-  - Nimble (6.0.1)
+  - Nimble (6.1.0)
   - Nimble-Snapshots/Core (4.4.2):
     - FBSnapshotTestCase (~> 2.0)
     - Nimble
@@ -23,7 +23,7 @@ PODS:
 DEPENDENCIES:
   - FBSnapshotTestCase (from `https://github.com/facebook/ios-snapshot-test-case.git`)
   - Forgeries
-  - Nimble (~> 6.0.1)
+  - Nimble (~> 6.1.0)
   - Nimble-Snapshots/DynamicSize (from `../`)
   - Nimble-Snapshots/DynamicType (from `../`)
   - Quick (~> 1.1.0)
@@ -40,13 +40,13 @@ CHECKOUT OPTIONS:
     :git: https://github.com/facebook/ios-snapshot-test-case.git
 
 SPEC CHECKSUMS:
-  FBSnapshotTestCase: '094f9f314decbabe373b87cc339bea235a63e07a'
+  FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a
   Forgeries: 64ced144ea8341d89a7eec9d1d7986f0f1366250
-  Nimble: 1527fd1bd2b4cf0636251a36bc8ab37e81da8347
+  Nimble: c53e6903fee94041b90ded74f135820437d8bf59
   Nimble-Snapshots: 9dc8c47ce13d68652caf2510d697c25eb732e487
   OCMock: 35ae71d6a8fcc1b59434d561d1520b9dd4f15765
   Quick: dafc587e21eed9f4cab3249b9f9015b0b7a7f71d
 
-PODFILE CHECKSUM: 519ab3b5519a34640cc5639010042334331331ab
+PODFILE CHECKSUM: 206301e00d9b7d4f66d75631eed31bed269c2a41
 
-COCOAPODS: 1.2.0
+COCOAPODS: 1.2.1

--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
-github "Quick/Quick" ~> 1.0.0
-github "Quick/Nimble" ~> 5.1.1
+github "Quick/Quick" ~> 1.1.0
+github "Quick/Nimble" ~> 6.1.0
 github "facebook/ios-snapshot-test-case" "2.1.4"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "Quick/Nimble" "v5.1.1"
-github "Quick/Quick" "v1.0.0"
+github "Quick/Nimble" "v6.1.0"
+github "Quick/Quick" "v1.1.0"
 github "facebook/ios-snapshot-test-case" "2.1.4"

--- a/HaveValidSnapshot.swift
+++ b/HaveValidSnapshot.swift
@@ -182,7 +182,13 @@ func _recordSnapshot(_ name: String?, isDeviceAgnostic: Bool = false, usesDrawRe
         let name = name ?? snapshotName
         failureMessage.expected = "snapshot \(name) successfully recorded, replace recordSnapshot with a check"
     } else {
-        failureMessage.expected = "expected to record a snapshot in \(name)"
+        let expectedMessage: String
+        if let name = name {
+            expectedMessage = "expected to record a snapshot in \(name)"
+        } else {
+            expectedMessage = "expected to record a snapshot"
+        }
+        failureMessage.expected = expectedMessage
     }
 
     return false

--- a/NimbleSnapshotsConfiguration.swift
+++ b/NimbleSnapshotsConfiguration.swift
@@ -14,13 +14,6 @@ class FBSnapshotTestConfiguration: QuickConfiguration {
     }
 }
 
-// Extracted from https://github.com/Quick/Nimble/blob/master/Sources/Nimble/Adapters/NimbleXCTestHandler.swift
-extension XCTestObservationCenter {
-    override open class func initialize() {
-        self.shared().addTestObserver(CurrentTestCaseTracker.shared)
-    }
-}
-
 /// Helper class providing access to the currently executing XCTestCase instance, if any
 @objc final class CurrentTestCaseTracker: NSObject, XCTestObservation {
     @objc static let shared = CurrentTestCaseTracker()


### PR DESCRIPTION
# What

Updated the Nimble and Quick dependencies to latest version and removed compiler warning introduced with Swift 3.1

# How

I have updated the Carthage metadata to use the current last version of Nimble and Quick and tweaked print of an optional string to make Swift 3.1 happy.

# Note

In latest version of Quick the `XCTestObservationCenter` has changed its implementation to suffice the lack of support for the `initialize()` method (which was override here). Current implementation on Quick this issue has been solved by using swizzling for which I'm not sure how to make it play nice with `Nimble-Snapshots`. Maybe @marcelofabri can have a look to workout together what might be the best solution. 