### PR TITLE
Fix Carthage installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Nimble-Snapshots
 
+## Next
+* Update the Cartfile to use always the latest stable release of Nimble and Quick.
+* Fix issue with the installation using Carthage.
+* Changed use of deprecated `MatcherFunc` to `Predicate` in favor of `Nimble v7.0.0`.
+
 ## master
 
 * Drops support for Swift 2.3 - @marcelofabri

--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
-github "Quick/Quick" ~> 1.1.0
-github "Quick/Nimble" ~> 6.1.0
+github "Quick/Quick"
+github "Quick/Nimble"
 github "facebook/ios-snapshot-test-case" "2.1.4"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "Quick/Nimble" "v6.1.0"
+github "Quick/Nimble" "v7.0.0"
 github "Quick/Quick" "v1.1.0"
 github "facebook/ios-snapshot-test-case" "2.1.4"

--- a/HaveValidSnapshot.swift
+++ b/HaveValidSnapshot.swift
@@ -210,9 +210,9 @@ private func currentTestName() -> String? {
 internal var switchChecksWithRecords = false
 
 public func haveValidSnapshot(named name: String? = nil, usesDrawRect: Bool = false,
-                              tolerance: CGFloat? = nil) -> MatcherFunc<Snapshotable> {
+                              tolerance: CGFloat? = nil) -> Predicate<Snapshotable> {
 
-    return MatcherFunc { actualExpression, failureMessage in
+    return Predicate.fromDeprecatedClosure { actualExpression, failureMessage in
         if switchChecksWithRecords {
             return recordSnapshot(name, usesDrawRect: usesDrawRect, actualExpression: actualExpression,
                                   failureMessage: failureMessage)
@@ -224,9 +224,9 @@ public func haveValidSnapshot(named name: String? = nil, usesDrawRect: Bool = fa
 }
 
 public func haveValidDeviceAgnosticSnapshot(named name: String? = nil, usesDrawRect: Bool = false,
-                                            tolerance: CGFloat? = nil) -> MatcherFunc<Snapshotable> {
+                                            tolerance: CGFloat? = nil) -> Predicate<Snapshotable> {
 
-    return MatcherFunc { actualExpression, failureMessage in
+    return Predicate.fromDeprecatedClosure { actualExpression, failureMessage in
         if switchChecksWithRecords {
             return recordSnapshot(name, isDeviceAgnostic: true, usesDrawRect: usesDrawRect,
                                   actualExpression: actualExpression, failureMessage: failureMessage)
@@ -238,18 +238,18 @@ public func haveValidDeviceAgnosticSnapshot(named name: String? = nil, usesDrawR
     }
 }
 
-public func recordSnapshot(named name: String? = nil, usesDrawRect: Bool = false) -> MatcherFunc<Snapshotable> {
-
-    return MatcherFunc { actualExpression, failureMessage in
+public func recordSnapshot(named name: String? = nil, usesDrawRect: Bool = false) -> Predicate<Snapshotable> {
+    
+    return Predicate.fromDeprecatedClosure { actualExpression, failureMessage in
         return recordSnapshot(name, usesDrawRect: usesDrawRect,
                               actualExpression: actualExpression, failureMessage: failureMessage)
     }
 }
 
 public func recordDeviceAgnosticSnapshot(named name: String? = nil,
-                                         usesDrawRect: Bool = false) -> MatcherFunc<Snapshotable> {
+                                         usesDrawRect: Bool = false) -> Predicate<Snapshotable> {
 
-    return MatcherFunc { actualExpression, failureMessage in
+    return Predicate.fromDeprecatedClosure { actualExpression, failureMessage in
         return recordSnapshot(name, isDeviceAgnostic: true, usesDrawRect: usesDrawRect,
                               actualExpression: actualExpression, failureMessage: failureMessage)
     }


### PR DESCRIPTION
After try to install the library using Carthage with:

    carthage bootstrap --platform iOS --toolchain com.apple.dt.toolchain.Swift_3_0

Carthage was failing with all the possible configurations (`branch`, `tag`, `commit`, etc) with the following message:

```bash
*** Checking out Nimble-Snapshots at "4.4.0"
*** xcodebuild output can be found in /var/folders/qv/yc3_zfm952d53b12jssfrkhjn409z6/T/carthage-xcodebuild.3kxun4.log
*** Skipped building Nimble-Snapshots due to the error:
Dependency "Nimble-Snapshots" has no shared framework schemes for any of the platforms: iOS
```

The strange thing is the project it have a  valid shared scheme. Afterwards I tried to validate Carthage for the project using:

    carthage build --no-skip-current

And it was giving errors too. 

After change the `Cartfile` to use always the latest version of `Quick` and `Nimble` instead of the compatible with version `x.x` and ran `carthage update --platform ios` I was be able to ran `carthage build --no-skip-current` successfully generating the  framework.

After integrate the new version of Nimble `v7.0.0` I was receiving some warning for a deprecated `MatcherFunc`, according to [Nimble v7.0.0](https://github.com/Quick/Nimble/releases/tag/v7.0.0) this was deprecated in favor of the new `Predicate`.

I solved it the warning replacing the `MatcherFunc` with the new `Predicate` and to keep the structure of the project for the moment until the new version of Nimble cames out, I used the recommended:

    Predicate.fromDeprecatedClosure { actualExpression, failureMessage -> Bool in ... }

To remove the warnings. Of course a more completed solution would be change completely to support `Predicates` without use the `fromDeprecatedClosure` function, but I found some issues regarding the new `Predicate` is expecting a `ExpectedMessage` instead a `FailureMessage` that its returned ins this moment.

