### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ You need to be using Carthage 0.18 or higher. Your `Cartfile` (or `Cartfile.priv
 something like the following.
 
 ```rb
-github "Quick/Quick" ~> 1.0.0
-github "Quick/Nimble" ~> 5.1.1
+github "Quick/Quick" ~> 1.0
+github "Quick/Nimble" ~> 5.1
 github "facebook/ios-snapshot-test-case" "2.1.4"
-github "Wallapop/Nimble-Snapshots"  ~> 4.4.0
+github "ashfurrow/Nimble-Snapshots"  ~> 5.0
 ```
 
 Then run:

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ something like the following.
 
 ```rb
 github "Quick/Quick" ~> 1.0
-github "Quick/Nimble" ~> 5.1
+github "Quick/Nimble" ~> 7.0
 github "facebook/ios-snapshot-test-case" "2.1.4"
 github "ashfurrow/Nimble-Snapshots"  ~> 5.0
 ```


### PR DESCRIPTION
I don't really know how Carthage works, but I'd expect those `~>` to support `x.y` instead of `x.z.y` which is better overall.

Plus I assume we want to be sending people to this repo too?