### PR TITLE
Add the tvOS deployment target to the podspec.

### DIFF
--- a/Nimble-Snapshots.podspec
+++ b/Nimble-Snapshots.podspec
@@ -9,7 +9,8 @@ Pod::Spec.new do |s|
   s.license      = { :type => "MIT", :file => "LICENSE" }
   s.author             = { "Ash Furrow" => "ash@ashfurrow.com" }
   s.social_media_url   = "http://twitter.com/ashfurrow"
-  s.platform     = :ios, "8.0"
+  s.ios.deployment_target = "8.0"
+  s.tvos.deployment_target = "9.0"
   s.pod_target_xcconfig = { 'ENABLE_BITCODE' => 'NO' }
   s.source       = { :git => "https://github.com/ashfurrow/Nimble-Snapshots.git", :tag => s.version }
   s.default_subspec = "Core"


### PR DESCRIPTION
I added the deployment target tvOs (minimum 9.0) to the `podspec` file. I thought there was more work do do, but this seems to do the trick perfectly.

In my current tvOS application I integrated this PR and it works great without having to change a line of code.

Hope this gets merged into the original repo. 🤞