### PR TITLE
Explicitly requiring Nimble ~> 7.0

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "Quick/Nimble"
+github "Quick/Nimble" ~> 7.0
 github "facebook/ios-snapshot-test-case" "2.1.4"


### PR DESCRIPTION
See https://github.com/ashfurrow/Nimble-Snapshots/issues/75#issuecomment-312726545.
The lack of a version requirement can lead to a compilation error if clients have an incompatible version of `Nimble`. With this change it will result in `Carthage` failing to resolve dependency versions.

This also matches [the version required for `CocoaPods`](https://github.com/ashfurrow/Nimble-Snapshots/blob/2dc8878568c1e5207c938bf1e154a30a93de757c/Nimble-Snapshots.podspec#L22).