### PR TITLE
Make FBSnapshotTest.sharedInstance public

### DIFF
--- a/HaveValidSnapshot.swift
+++ b/HaveValidSnapshot.swift
@@ -27,7 +27,7 @@ extension UIView : Snapshotable {
     var referenceImagesDirectory: String?
     var tolerance: CGFloat = 0
 
-    static let sharedInstance = FBSnapshotTest()
+    public static let sharedInstance = FBSnapshotTest()
 
     public class func setReferenceImagesDirectory(_ directory: String?) {
         sharedInstance.referenceImagesDirectory = directory


### PR DESCRIPTION
Hey @ashfurrow, wondered if you'd be ok with making [FBSnapshotTest.sharedInstance](https://github.com/ashfurrow/Nimble-Snapshots/blob/121c5261ca8da1e4861c1976430ae4c895df9b42/HaveValidSnapshot.swift#L30) public. Otherwise there's no way to set `tolerance` at a global test level for all tests, for example :) 

Made the PR, feel free to reject if this is something that doesn't make sense.

Thanks!