### PR TITLE
Issue #145 fixed check to use both height and width instead of just width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Migrate from FBSnapshotTestCase to iOSSnapshotTestCase - @freak4pc
 * Update the `README` to use the new iOSSnapshotTestCase - @Vkt0r
 * Update the `Cartfile` to use the latest version of the iOSSnapshotTestCase - @Vkt0r
+* Fixed bug in the iOS9+ first-pass-layout-workaround to check both height and width (was a typo) [#145](https://github.com/ashfurrow/Nimble-Snapshots/issues/145) - @davertay
 
 
 ## 6.3.0

--- a/DynamicSize/DynamicSizeSnapshot.swift
+++ b/DynamicSize/DynamicSizeSnapshot.swift
@@ -68,7 +68,7 @@ class ConstraintViewResizer: ViewResizer {
         //iOS 9+ BUG: Before the first draw, iOS will not calculate the layout, 
         // it add a _UITemporaryLayoutWidth equals to its bounds and create a conflict. 
         // So to it do all the layout we create a Window and add it as subview
-        if view.bounds.width != size.width || view.bounds.width != size.width {
+        if view.bounds.width != size.width || view.bounds.height != size.height {
             let window = UIWindow(frame: CGRect(origin: .zero, size: size))
             let viewController = UIViewController()
             viewController.view = UIView()


### PR DESCRIPTION
https://github.com/ashfurrow/Nimble-Snapshots/issues/145

Consensus is that this was a typo.