### PR TITLE
image names as attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Nothing yet!
 
+## 6.7.1
+
+* Change the images name for XCAttachments based on the origin image's name - @maryam
+
 ## 6.7.0
 
 * Add test images to the test results as XCAttachments - @tabend

--- a/HaveValidSnapshot.swift
+++ b/HaveValidSnapshot.swift
@@ -54,7 +54,7 @@ extension UIView : Snapshotable {
             try snapshotController.compareSnapshot(ofViewOrLayer: instance.snapshotObject,
                                                  selector: Selector(snapshot), identifier: identifier, tolerance: tolerance)
             let image = try snapshotController.referenceImage(for: Selector(snapshot), identifier: identifier)
-            attach(image: image, named: "Reference Image")
+            attach(image: image, named: "Reference_\(reason)")
         } catch let error {
             let info = (error as NSError).userInfo
             if let ref = info[FBReferenceImageKey] as? UIImage {

--- a/HaveValidSnapshot.swift
+++ b/HaveValidSnapshot.swift
@@ -58,13 +58,13 @@ extension UIView : Snapshotable {
         } catch let error {
             let info = (error as NSError).userInfo
             if let ref = info[FBReferenceImageKey] as? UIImage {
-                attach(image: ref, named: "Reference Image")
+                attach(image: ref, named: "Reference_\(reason)")
             }
             if let captured = info[FBCapturedImageKey] as? UIImage {
-                attach(image: captured, named: "Captured Image")
+                attach(image: captured, named: "Captured_\(reason)")
             }
             if let diff = info[FBDiffedImageKey] as? UIImage {
-                attach(image: diff, named: "Diffed Image")
+                attach(image: diff, named: "Diffed_\(reason)")
             }
             return false
         }

--- a/HaveValidSnapshot.swift
+++ b/HaveValidSnapshot.swift
@@ -54,17 +54,17 @@ extension UIView : Snapshotable {
             try snapshotController.compareSnapshot(ofViewOrLayer: instance.snapshotObject,
                                                  selector: Selector(snapshot), identifier: identifier, tolerance: tolerance)
             let image = try snapshotController.referenceImage(for: Selector(snapshot), identifier: identifier)
-            attach(image: image, named: "Reference_\(reason)")
+            attach(image: image, named: "Reference_\(snapshot)")
         } catch let error {
             let info = (error as NSError).userInfo
             if let ref = info[FBReferenceImageKey] as? UIImage {
-                attach(image: ref, named: "Reference_\(reason)")
+                attach(image: ref, named: "Reference_\(snapshot)")
             }
             if let captured = info[FBCapturedImageKey] as? UIImage {
-                attach(image: captured, named: "Captured_\(reason)")
+                attach(image: captured, named: "Captured_\(snapshot)")
             }
             if let diff = info[FBDiffedImageKey] as? UIImage {
-                attach(image: diff, named: "Diffed_\(reason)")
+                attach(image: diff, named: "Diffed_\(snapshot)")
             }
             return false
         }


### PR DESCRIPTION
images created in attachment of test report they all have same name. reason string can be added to be more readable in reports !
![screen shot 2018-05-24 at 4 58 50 pm](https://user-images.githubusercontent.com/33662696/40513919-36385b90-5f75-11e8-8b54-c9cda0ff5a2f.png)
