### PR TITLE
Reference directory path as environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-- Nothing yet!
+* Load reference images directory path from environment variable if present - @aniastrzezek
 
 ## 6.7.1
 

--- a/HaveValidSnapshot.swift
+++ b/HaveValidSnapshot.swift
@@ -95,6 +95,10 @@ func getDefaultReferenceDirectory(_ sourceFileName: String) -> String {
     if let globalReference = FBSnapshotTest.sharedInstance.referenceImagesDirectory {
         return globalReference
     }
+    
+    if let environmentReference = ProcessInfo.processInfo.environment["FB_REFERENCE_IMAGE_DIR"] {
+        return environmentReference
+    }
 
     // Search the test file's path to find the first folder with a test suffix,
     // then append "/ReferenceImages" and use that.
@@ -111,7 +115,8 @@ func getDefaultReferenceDirectory(_ sourceFileName: String) -> String {
 
     guard let testDirectory = testPath else {
         fatalError("Could not infer reference image folder – You should provide a reference dir using " +
-                   "FBSnapshotTest.setReferenceImagesDirectory(FB_REFERENCE_IMAGE_DIR)")
+                   "FBSnapshotTest.setReferenceImagesDirectory(FB_REFERENCE_IMAGE_DIR) " +
+                   "or by setting the FB_REFERENCE_IMAGE_DIR environment variable")
     }
 
     // Recombine the path components and append our own image directory.


### PR DESCRIPTION
This PR makes it possible to define reference directory path by setting the value of `FB_REFERENCE_IMAGE_DIR` environment variable.