### PR TITLE
Add second_curtain to the project

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,6 @@ jobs:
       xcode: "9.3.0"
     working_directory: /Users/distiller/project
     environment:
-      FL_OUTPUT_DIR: output
       BUNDLE_PATH: vendor/bundle
     steps:
       - checkout
@@ -24,13 +23,24 @@ jobs:
             - vendor/bundle
       - run:
           name: "Run tests"
-          command: rake test
+          command: |
+              mkdir output
+              rake test
+      - run: 
+          name: second curtain
+          command: bundle exec second_curtain output/xcodebuild.log
+          when: on_fail
       - run:
           name: "Run Carthage integration test"
           command: rake carthage
       - run:
           name: "Run Danger"
           command: bundle exec danger
+      - store_artifacts:
+          path: output/
+      - store_test_results:
+          path: output/
+                 
 
 workflows:
   version: 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-* Nothing yet!
+* Add [second_curtain](https://github.com/ashfurrow/second_curtain) to the project - @Vkt0r
 
 ## 6.8.1
 

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gem 'cocoapods', '~> 1.2'
 gem 'xcpretty'
 gem 'rake'
+gem 'second_curtain', '~> 0.2'
 
 group :test do
   gem 'danger'

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@ require 'tmpdir'
 
 desc 'Run unit tests on iOS 11.2'
 task :test do
-  sh "set -o pipefail && xcodebuild -workspace 'Bootstrap/Bootstrap.xcworkspace' -sdk 'iphonesimulator' -scheme 'Bootstrap' -destination 'name=iPhone 6,OS=11.2' build test | xcpretty --color --simple"
+  sh "set -o pipefail && xcodebuild -workspace 'Bootstrap/Bootstrap.xcworkspace' -sdk 'iphonesimulator' -scheme 'Bootstrap' -destination 'name=iPhone 6,OS=11.2' build test | tee output/xcodebuild.log | xcpretty --color --simple"
 end
 
 desc 'Lint the library for CocoaPods usage'


### PR DESCRIPTION
@ashfurrow I was following the discussion in #163 with @freak4pc about the tests failing in the CI and I worked with `second_curtain` (thanks for it 👏) in CircleCI for a while with excellent results so far ! So I decided to create this PR to add it to the project in case of we have failing test. 
 
Ash I think I can leave the part of add the ENV variables for the bucket in AWS to you 😅 as I don't have any clue which one we would like to use for the project 😀.

The PR can be resumed in the following:

* Include the logs for xcodebuild to use it with second_curtain.
* Run second_curtain only when some step fails to check for failed snapshot tests.
* Remove the unnecessary fastlane output directory ENV variable from the config file.
* Create a dir in the CI to store the results from xcodebuild logs.
* Store the artifacts and test results to have more information about any failure.

Happy review 😅!