### PR TITLE
Use IMAGE_DIFF_DIR environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next
 
 * Add [second_curtain](https://github.com/ashfurrow/second_curtain) to the project - @Vkt0r
+* Set image diff directory from environment variable if present - @flobories
 
 ## 6.8.1
 

--- a/HaveValidSnapshot.swift
+++ b/HaveValidSnapshot.swift
@@ -45,7 +45,7 @@ extension UIView : Snapshotable {
         snapshotController.isDeviceAgnostic = isDeviceAgnostic
         snapshotController.recordMode = record
         snapshotController.referenceImagesDirectory = referenceDirectory
-        snapshotController.imageDiffDirectory = NSTemporaryDirectory()
+        snapshotController.imageDiffDirectory = defaultImageDiffDirectory
         snapshotController.usesDrawViewHierarchyInRect = usesDrawRect
 
         let reason = "Missing value for referenceImagesDirectory - " +
@@ -127,6 +127,13 @@ func getDefaultReferenceDirectory(_ sourceFileName: String) -> String {
     let folderPath = folderPathComponents.componentsJoined(by: "/")
 
     return folderPath + "/ReferenceImages"
+}
+
+private var defaultImageDiffDirectory: String {
+    if let environmentReference = ProcessInfo.processInfo.environment["IMAGE_DIFF_DIR"] {
+        return environmentReference
+    }
+    return NSTemporaryDirectory()
 }
 
 private func parseFilename(filename: String) -> String {


### PR DESCRIPTION
Resolves #169

Favor `IMAGE_DIFF_DIR` environment variable over temporary directory for image diffs, so that user can specify a diff directory.
If no environment variable is set `IMAGE_DIFF_DIR`, use `NSTemporaryDirectory()`