### PR TITLE
Run second_curtain in the pipeline of xcodebuild directly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
       - checkout
       - *restore_bundle_cache
       - *bunde_install
-      - *restore_bundle_cache
+      - *save_bundle_cache
       - run:
           name: "Run Danger"
           command: bundle exec danger
@@ -43,18 +43,10 @@ jobs:
           command: mkdir output
       - run:
           name: "Run tests in Swift 4.0"
-          command: xcodebuild -workspace 'Bootstrap/Bootstrap.xcworkspace' -sdk 'iphonesimulator' -scheme 'Bootstrap' -destination 'name=iPhone 8' SWIFT_VERSION=4.0 build test | tee output/xcodebuild_swift4.0.log | xcpretty --color --simple
-      - run: 
-          name: second curtain
-          command: bundle exec second_curtain output/xcodebuild_swift4.0.log
-          when: on_fail
+          command: xcodebuild -workspace 'Bootstrap/Bootstrap.xcworkspace' -sdk 'iphonesimulator' -scheme 'Bootstrap' -destination 'name=iPhone 8' SWIFT_VERSION=4.0 build test | bundle exec second_curtain | tee output/xcodebuild_swift4.0.log | xcpretty --color --simple
       - run:
           name: "Run tests in Swift 4.2"
-          command: xcodebuild -workspace 'Bootstrap/Bootstrap.xcworkspace' -sdk 'iphonesimulator' -scheme 'Bootstrap' -destination 'name=iPhone 8' SWIFT_VERSION=4.2 build test | tee output/xcodebuild_swift4.2.log | xcpretty --color --simple
-      - run: 
-          name: second curtain
-          command: bundle exec second_curtain output/xcodebuild_swift4.2.log
-          when: on_fail
+          command: xcodebuild -workspace 'Bootstrap/Bootstrap.xcworkspace' -sdk 'iphonesimulator' -scheme 'Bootstrap' -destination 'name=iPhone 8' SWIFT_VERSION=4.2 build test | bundle exec second_curtain | tee output/xcodebuild_swift4.2.log | xcpretty --color --simple
       - run:
           name: "Run Carthage integration test"
           command: carthage bootstrap --platform iOS && xcodebuild | xcpretty --color --simple

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next
 
+* Run [second_curtain](https://github.com/ashfurrow/second_curtain) in the pipeline of `xcodebuild` - @Vkt0r
 * Xcode 10 Support (Swift 4 & Swift 4.2). @freak4pc
 * Add [second_curtain](https://github.com/ashfurrow/second_curtain) to the project - @Vkt0r
 


### PR DESCRIPTION
We had `second_curtain` previously running with the output of `xcodebuild` separately and only if the build fails, the problem is the `when: on_fails` runs if some builds fail both `on_fails` will run causing the build for Swift 4.2 never being created 😅.

Also for some reason we lost the change I made before causing the cache wasn’t saved after `bundle install`.