### PR TITLE
Enable more SwiftLint opt-in rules #trivial

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,19 +1,48 @@
 opt_in_rules:
-  - empty_count
-  - force_unwrapping
+  - anyobject_protocol
+  - array_init
+  - attributes
   - closure_end_indentation
   - closure_spacing
-  - conditional_returns_on_newline
+  - conditional_returns_on_newline 
+  - convenience_type
+  - discouraged_object_literal
+  - discouraged_optional_boolean  
+  - empty_count
+  - empty_string    
   - explicit_init
+  - fatal_error_message
+  - file_length
   - first_where
+  - force_cast
+  - force_try
+  - force_unwrapping  
+  - implicitly_unwrapped_optional
+  - joined_default_parameter
+  - modifier_order
+  - multiline_parameters
   - operator_usage_whitespace
   - overridden_super_call
+  - override_in_extension    
+  - prefixed_toplevel_constant
+  - private_action
+  - private_outlet
   - prohibited_super_call
+  - redundant_nil_coalescing
+  - sorted_first_last  
   - sorted_imports
   - switch_case_on_newline
-  - redundant_nil_coalescing
+  - trailing_closure
+  - unavailable_function
+  - unneeded_parentheses_in_closure_argument
+  - vertical_parameter_alignment_on_call
+  - yoda_condition
+
 disabled_rules:
   - identifier_name
+
 excluded:
   - Bootstrap/Pods
   - Carthage
+
+reporter: "xcode"      

--- a/Bootstrap/Bootstrap/AppDelegate.swift
+++ b/Bootstrap/Bootstrap/AppDelegate.swift
@@ -25,7 +25,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let version = ProcessInfo.processInfo.operatingSystemVersion
         let minVersion = OperatingSystemVersion(majorVersion: 9, minorVersion: 3, patchVersion: 0)
         assert(ProcessInfo.processInfo.isOperatingSystemAtLeast(minVersion),
-                 "The tests should be run at least on iOS 9.3, not \(version.majorVersion), \(version.minorVersion)")
+               "The tests should be run at least on iOS 9.3, not \(version.majorVersion), \(version.minorVersion)")
 
         #if swift(>=4.2)
         let stringFromSize: (CGSize) -> String = { NSCoder.string(for: $0) }

--- a/Bootstrap/Bootstrap/DynamicTypeView.swift
+++ b/Bootstrap/Bootstrap/DynamicTypeView.swift
@@ -4,7 +4,7 @@ import UIKit
 public final class DynamicTypeView: UIView {
     public let label: UILabel
 
-    public override init(frame: CGRect) {
+    override public init(frame: CGRect) {
         label = UILabel()
         super.init(frame: frame)
 
@@ -26,12 +26,12 @@ public final class DynamicTypeView: UIView {
         #endif
 
         NotificationCenter.default.addObserver(self, selector: #selector(updateFonts),
-                                                         name: notName,
-                                                         object: nil)
+                                               name: notName,
+                                               object: nil)
     }
 
     private var createdConstraints = false
-    public override func updateConstraints() {
+    override public func updateConstraints() {
         if !createdConstraints {
             label.leadingAnchor.constraint(equalTo: leadingAnchor).isActive = true
             label.trailingAnchor.constraint(equalTo: trailingAnchor).isActive = true
@@ -42,7 +42,8 @@ public final class DynamicTypeView: UIView {
         super.updateConstraints()
     }
 
-    @objc func updateFonts(_ notification: Notification) {
+    @objc
+    func updateFonts(_ notification: Notification) {
         #if swift(>=4.2)
         let newValueKey = UIContentSizeCategory.newValueUserInfoKey
         #else
@@ -57,6 +58,7 @@ public final class DynamicTypeView: UIView {
         label.text = category.replacingOccurrences(of: "UICTContentSizeCategory", with: "")
     }
 
+    @available(*, unavailable)
     public required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/Bootstrap/BootstrapTests/.swiftlint.yml
+++ b/Bootstrap/BootstrapTests/.swiftlint.yml
@@ -1,19 +1,20 @@
 opt_in_rules:
-  - empty_count
-  - force_unwrapping
   - closure_end_indentation
   - closure_spacing
   - conditional_returns_on_newline
+  - empty_count
   - explicit_init
   - first_where
+  - force_unwrapping
   - operator_usage_whitespace
   - overridden_super_call
   - prohibited_super_call
+  - redundant_nil_coalescing
   - sorted_imports
   - switch_case_on_newline
-  - redundant_nil_coalescing
 
 disabled_rules:
-  function_body_length
+  - function_body_length
+  - implicitly_unwrapped_optional
 
 line_length: 200

--- a/Bootstrap/BootstrapTests/DynamicSizeTests.swift
+++ b/Bootstrap/BootstrapTests/DynamicSizeTests.swift
@@ -101,7 +101,7 @@ class DynamicSizeTests: QuickSpec {
                 }
 
                 it("has a valid snapshot to all sizes (using == operator)") {
-                    expect(view) == snapshot(sizes: sizes, resizeMode: .block(resizeBlock: { (view, size) in
+                    expect(view) == snapshot(sizes: sizes, resizeMode: .block(resizeBlock: { view, size in
                         view.frame = CGRect(origin: .zero, size: size)
                         view.layoutIfNeeded()
                     }))

--- a/CurrentTestCaseTracker.swift
+++ b/CurrentTestCaseTracker.swift
@@ -1,16 +1,19 @@
 import XCTest
 
 /// Helper class providing access to the currently executing XCTestCase instance, if any
-@objc public final class CurrentTestCaseTracker: NSObject, XCTestObservation {
+@objc
+public final class CurrentTestCaseTracker: NSObject, XCTestObservation {
     @objc public static let shared = CurrentTestCaseTracker()
 
     private(set) var currentTestCase: XCTestCase?
 
-    @objc public func testCaseWillStart(_ testCase: XCTestCase) {
+    @objc
+    public func testCaseWillStart(_ testCase: XCTestCase) {
         currentTestCase = testCase
     }
 
-    @objc public func testCaseDidFinish(_ testCase: XCTestCase) {
+    @objc
+    public func testCaseDidFinish(_ testCase: XCTestCase) {
         currentTestCase = nil
     }
 }

--- a/DynamicSize/DynamicSizeSnapshot.swift
+++ b/DynamicSize/DynamicSizeSnapshot.swift
@@ -81,8 +81,8 @@ class ConstraintViewResizer: ViewResizer {
     }
 
     func findConstrains(of view: UIView) -> SizeConstrainsWrapper {
-        var height: NSLayoutConstraint!
-        var width: NSLayoutConstraint!
+        var height: NSLayoutConstraint! // swiftlint:disable:this implicitly_unwrapped_optional
+        var width: NSLayoutConstraint! // swiftlint:disable:this implicitly_unwrapped_optional
 
         #if swift(>=4.2)
         let heightLayout = NSLayoutConstraint.Attribute.height
@@ -138,13 +138,18 @@ public struct DynamicSizeSnapshot {
     }
 }
 
-public func snapshot(_ name: String? = nil, identifier: String? = nil, sizes: [String: CGSize],
+public func snapshot(_ name: String? = nil,
+                     identifier: String? = nil,
+                     sizes: [String: CGSize],
                      resizeMode: ResizeMode = .frame) -> DynamicSizeSnapshot {
     return DynamicSizeSnapshot(name: name, identifier: identifier, record: false, sizes: sizes, resizeMode: resizeMode)
 }
 
-public func haveValidDynamicSizeSnapshot(named name: String? = nil, identifier: String? = nil, sizes: [String: CGSize],
-                                         isDeviceAgnostic: Bool = false, usesDrawRect: Bool = false,
+public func haveValidDynamicSizeSnapshot(named name: String? = nil,
+                                         identifier: String? = nil,
+                                         sizes: [String: CGSize],
+                                         isDeviceAgnostic: Bool = false,
+                                         usesDrawRect: Bool = false,
                                          tolerance: CGFloat? = nil,
                                          resizeMode: ResizeMode = .frame) -> Predicate<Snapshotable> {
     return Predicate.fromDeprecatedClosure { actualExpression, failureMessage in
@@ -166,8 +171,11 @@ func performDynamicSizeSnapshotTest(_ name: String?,
                                     identifier: String? = nil,
                                     sizes: [String: CGSize],
                                     isDeviceAgnostic: Bool = false,
-                                    usesDrawRect: Bool = false, actualExpression: Expression<Snapshotable>,
-                                    failureMessage: FailureMessage, tolerance: CGFloat? = nil, isRecord: Bool,
+                                    usesDrawRect: Bool = false,
+                                    actualExpression: Expression<Snapshotable>,
+                                    failureMessage: FailureMessage,
+                                    tolerance: CGFloat? = nil,
+                                    isRecord: Bool,
                                     resizeMode: ResizeMode) -> Bool {
     // swiftlint:disable:next force_try force_unwrapping
     let instance = try! actualExpression.evaluate()!
@@ -178,7 +186,7 @@ func performDynamicSizeSnapshotTest(_ name: String?,
 
     let resizer = resizeMode.viewResizer()
 
-    let result = sizes.map { (sizeName, size) -> Bool in
+    let result = sizes.map { sizeName, size -> Bool in
         // swiftlint:disable:next force_unwrapping
         let view = instance.snapshotObject!
         let finalSnapshotName: String
@@ -217,13 +225,18 @@ func performDynamicSizeSnapshotTest(_ name: String?,
     }
 }
 
-public func recordSnapshot(_ name: String? = nil, identifier: String? = nil, sizes: [String: CGSize],
+public func recordSnapshot(_ name: String? = nil,
+                           identifier: String? = nil,
+                           sizes: [String: CGSize],
                            resizeMode: ResizeMode = .frame) -> DynamicSizeSnapshot {
     return DynamicSizeSnapshot(name: name, identifier: identifier, record: true, sizes: sizes, resizeMode: resizeMode)
 }
 
-public func recordDynamicSizeSnapshot(named name: String? = nil, identifier: String? = nil, sizes: [String: CGSize],
-                                      isDeviceAgnostic: Bool = false, usesDrawRect: Bool = false,
+public func recordDynamicSizeSnapshot(named name: String? = nil,
+                                      identifier: String? = nil,
+                                      sizes: [String: CGSize],
+                                      isDeviceAgnostic: Bool = false,
+                                      usesDrawRect: Bool = false,
                                       resizeMode: ResizeMode = .frame) -> Predicate<Snapshotable> {
     return Predicate.fromDeprecatedClosure { actualExpression, failureMessage in
         return performDynamicSizeSnapshotTest(name,

--- a/DynamicType/HaveValidDynamicTypeSnapshot.swift
+++ b/DynamicType/HaveValidDynamicTypeSnapshot.swift
@@ -15,7 +15,8 @@ func shortCategoryName(_ category: UIContentSizeCategory) -> String {
     return category.rawValue.replacingOccurrences(of: "UICTContentSizeCategory", with: "")
 }
 
-func combinePredicates<T>(_ predicates: [Predicate<T>], ignoreFailures: Bool = false,
+func combinePredicates<T>(_ predicates: [Predicate<T>],
+                          ignoreFailures: Bool = false,
                           deferred: (() -> Void)? = nil) -> Predicate<T> {
     return Predicate.fromDeprecatedClosure { actualExpression, failureMessage in
         defer {
@@ -52,7 +53,7 @@ public func haveValidDynamicTypeSnapshot(named name: String? = nil,
             let predicate: Predicate<Snapshotable>
             if isDeviceAgnostic {
                 predicate = haveValidDeviceAgnosticSnapshot(named: nameWithCategory, identifier: identifier,
-                                                          usesDrawRect: usesDrawRect, tolerance: tolerance)
+                                                            usesDrawRect: usesDrawRect, tolerance: tolerance)
             } else {
                 predicate = haveValidSnapshot(named: nameWithCategory,
                                               identifier: identifier,
@@ -69,7 +70,9 @@ public func haveValidDynamicTypeSnapshot(named name: String? = nil,
     }
 }
 
-public func recordDynamicTypeSnapshot(named name: String? = nil, identifier: String? = nil, usesDrawRect: Bool = false,
+public func recordDynamicTypeSnapshot(named name: String? = nil,
+                                      identifier: String? = nil,
+                                      usesDrawRect: Bool = false,
                                       sizes: [UIContentSizeCategory] = allContentSizeCategories(),
                                       isDeviceAgnostic: Bool = false) -> Predicate<Snapshotable> {
     let mock = NBSMockedApplication()

--- a/DynamicType/PrettyDynamicTypeSyntax.swift
+++ b/DynamicType/PrettyDynamicTypeSyntax.swift
@@ -29,7 +29,8 @@ public func dynamicTypeSnapshot(_ name: String? = nil,
                                deviceAgnostic: deviceAgnostic)
 }
 
-public func recordDynamicTypeSnapshot(_ name: String? = nil, identifier: String? = nil,
+public func recordDynamicTypeSnapshot(_ name: String? = nil,
+                                      identifier: String? = nil,
                                       sizes: [UIContentSizeCategory] = allContentSizeCategories(),
                                       deviceAgnostic: Bool = false) -> DynamicTypeSnapshot {
     return DynamicTypeSnapshot(name: name,

--- a/HaveValidSnapshot.swift
+++ b/HaveValidSnapshot.swift
@@ -22,7 +22,8 @@ extension UIView: Snapshotable {
     }
 }
 
-@objc public class FBSnapshotTest: NSObject {
+@objc
+public class FBSnapshotTest: NSObject {
 
     var referenceImagesDirectory: String?
     var tolerance: CGFloat = 0
@@ -34,10 +35,15 @@ extension UIView: Snapshotable {
     }
 
     // swiftlint:disable:next function_parameter_count
-    class func compareSnapshot(_ instance: Snapshotable, isDeviceAgnostic: Bool = false,
-                               usesDrawRect: Bool = false, snapshot: String, record: Bool,
-                               referenceDirectory: String, tolerance: CGFloat,
-                               filename: String, identifier: String? = nil) -> Bool {
+    class func compareSnapshot(_ instance: Snapshotable,
+                               isDeviceAgnostic: Bool = false,
+                               usesDrawRect: Bool = false,
+                               snapshot: String,
+                               record: Bool,
+                               referenceDirectory: String,
+                               tolerance: CGFloat,
+                               filename: String,
+                               identifier: String? = nil) -> Bool {
 
         let testName = parseFilename(filename: filename)
         let snapshotController: FBSnapshotTestController = FBSnapshotTestController(test: self)
@@ -81,11 +87,11 @@ extension UIView: Snapshotable {
     }
 
     private static func attach(image: UIImage, named name: String) {
-        XCTContext.runActivity(named: name, block: { activity in
+        XCTContext.runActivity(named: name) { activity in
             let attachment = XCTAttachment(image: image)
             attachment.name = name
             activity.add(attachment)
-        })
+        }
     }
 }
 
@@ -247,7 +253,9 @@ private func currentTestName() -> String? {
 
 internal var switchChecksWithRecords = false
 
-public func haveValidSnapshot(named name: String? = nil, identifier: String? = nil, usesDrawRect: Bool = false,
+public func haveValidSnapshot(named name: String? = nil,
+                              identifier: String? = nil,
+                              usesDrawRect: Bool = false,
                               tolerance: CGFloat? = nil) -> Predicate<Snapshotable> {
 
     return Predicate.fromDeprecatedClosure { actualExpression, failureMessage in
@@ -295,7 +303,8 @@ public func recordSnapshot(named name: String? = nil,
     }
 }
 
-public func recordDeviceAgnosticSnapshot(named name: String? = nil, identifier: String? = nil,
+public func recordDeviceAgnosticSnapshot(named name: String? = nil,
+                                         identifier: String? = nil,
                                          usesDrawRect: Bool = false) -> Predicate<Snapshotable> {
 
     return Predicate.fromDeprecatedClosure { actualExpression, failureMessage in


### PR DESCRIPTION
This PR enable lots of opt-in rules and fixes them too.

**Rules fixed:**

- **Modifier Order Violation:** override modifier should be before public. (modifier_order)

- **Vertical Parameter Alignment On Call Violation:** Function parameters should be aligned vertically if they're in multiple lines in a method call. (vertical_parameter_alignment_on_call)

- **Unavailable Function Violation:** Unimplemented functions should be marked as unavailable. (unavailable_function)

- **Attributes Violation:** Attributes should be on their own lines in functions and types, but on the same line as variables and imports. (attributes)

- **Multiline Parameters Violation:** Functions and methods parameters should be either on the same line, or one per line. (multiline_parameters)

- **Unneeded Parentheses in Closure Argument Violation:** Parentheses are not needed when declaring closure arguments. (unneeded_parentheses_in_closure_argument)

- **Trailing Closure Violation:** Trailing closure syntax should be used whenever possible. (trailing_closure)

**Ignored:** (We need to think a way to fix this)

- **Implicitly Unwrapped Optional Violation:** Implicitly unwrapped optionals should be avoided when possible. (implicitly_unwrapped_optional) `DynamicSizeSnapshot.swift line 84 and 85`