### PR TITLE
Improve pixel tolerance support

### DIFF
--- a/Nimble_Snapshots/DynamicSize/DynamicSizeSnapshot.swift
+++ b/Nimble_Snapshots/DynamicSize/DynamicSizeSnapshot.swift
@@ -150,6 +150,7 @@ public func haveValidDynamicSizeSnapshot(named name: String? = nil,
                                          sizes: [String: CGSize],
                                          isDeviceAgnostic: Bool = false,
                                          usesDrawRect: Bool = false,
+                                         pixelTolerance: CGFloat? = nil,
                                          tolerance: CGFloat? = nil,
                                          resizeMode: ResizeMode = .frame) -> Predicate<Snapshotable> {
     return Predicate.fromDeprecatedClosure { actualExpression, failureMessage in
@@ -161,6 +162,7 @@ public func haveValidDynamicSizeSnapshot(named name: String? = nil,
                                               actualExpression: actualExpression,
                                               failureMessage: failureMessage,
                                               tolerance: tolerance,
+                                              pixelTolerance: pixelTolerance,
                                               isRecord: false,
                                               resizeMode: resizeMode)
     }

--- a/Nimble_Snapshots/DynamicType/HaveValidDynamicTypeSnapshot.swift
+++ b/Nimble_Snapshots/DynamicType/HaveValidDynamicTypeSnapshot.swift
@@ -37,6 +37,7 @@ func combinePredicates<T>(_ predicates: [Predicate<T>],
 public func haveValidDynamicTypeSnapshot(named name: String? = nil,
                                          identifier: String? = nil,
                                          usesDrawRect: Bool = false,
+                                         pixelTolerance: CGFloat? = nil,
                                          tolerance: CGFloat? = nil,
                                          sizes: [UIContentSizeCategory] = allContentSizeCategories(),
                                          isDeviceAgnostic: Bool = false) -> Predicate<Snapshotable> {
@@ -53,11 +54,13 @@ public func haveValidDynamicTypeSnapshot(named name: String? = nil,
             let predicate: Predicate<Snapshotable>
             if isDeviceAgnostic {
                 predicate = haveValidDeviceAgnosticSnapshot(named: nameWithCategory, identifier: identifier,
-                                                            usesDrawRect: usesDrawRect, tolerance: tolerance)
+                                                            usesDrawRect: usesDrawRect, pixelTolerance: pixelTolerance,
+                                                            tolerance: tolerance)
             } else {
                 predicate = haveValidSnapshot(named: nameWithCategory,
                                               identifier: identifier,
                                               usesDrawRect: usesDrawRect,
+                                              pixelTolerance: pixelTolerance,
                                               tolerance: tolerance)
             }
 

--- a/Nimble_Snapshots/HaveValidSnapshot.swift
+++ b/Nimble_Snapshots/HaveValidSnapshot.swift
@@ -301,6 +301,7 @@ public func haveValidSnapshot(named name: String? = nil,
 public func haveValidDeviceAgnosticSnapshot(named name: String? = nil,
                                             identifier: String? = nil,
                                             usesDrawRect: Bool = false,
+                                            pixelTolerance: CGFloat? = nil,
                                             tolerance: CGFloat? = nil) -> Predicate<Snapshotable> {
 
     return Predicate.fromDeprecatedClosure { actualExpression, failureMessage in
@@ -310,8 +311,8 @@ public func haveValidDeviceAgnosticSnapshot(named name: String? = nil,
         }
 
         return performSnapshotTest(name, identifier: identifier, isDeviceAgnostic: true, usesDrawRect: usesDrawRect,
-                                   actualExpression: actualExpression,
-                                   failureMessage: failureMessage, tolerance: tolerance)
+                                   actualExpression: actualExpression, failureMessage: failureMessage,
+                                   pixelTolerance: pixelTolerance, tolerance: tolerance)
     }
 }
 

--- a/Nimble_Snapshots/HaveValidSnapshot.swift
+++ b/Nimble_Snapshots/HaveValidSnapshot.swift
@@ -113,6 +113,10 @@ public func setNimbleTolerance(_ tolerance: CGFloat) {
     FBSnapshotTest.sharedInstance.tolerance = tolerance
 }
 
+public func setNimblePixelTolerance(_ pixelTolerance: CGFloat) {
+    FBSnapshotTest.sharedInstance.pixelTolerance = pixelTolerance
+}
+
 func getDefaultReferenceDirectory(_ sourceFileName: String) -> String {
     if let globalReference = FBSnapshotTest.sharedInstance.referenceImagesDirectory {
         return globalReference


### PR DESCRIPTION
The original PR added the pixel tolerance parameter to only `haveValidSnapshot`. This adds it to all of the `haveValid` functions.

The PR also added `pixelTolerance` to `FBSnapshotTest`, but as far as I could see, there was no public API to set this value. I've added `setNimblePixelTolerance` to match the other tolerance setter.