### PR TITLE
Fix issue where Nimble-Snapshots does not compile for tvOS using Carthage

### DIFF
--- a/Nimble_Snapshots.xcodeproj/project.pbxproj
+++ b/Nimble_Snapshots.xcodeproj/project.pbxproj
@@ -8,8 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		095B47711D4773F000880922 /* Nimble_Snapshots.h in Headers */ = {isa = PBXBuildFile; fileRef = 095B47701D4773F000880922 /* Nimble_Snapshots.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		095B47891D47761500880922 /* FBSnapshotTestCase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 095B47861D47761500880922 /* FBSnapshotTestCase.framework */; };
-		095B478A1D47761500880922 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 095B47871D47761500880922 /* Nimble.framework */; };
 		095B478F1D47794300880922 /* HaveValidSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 095B478C1D47794300880922 /* HaveValidSnapshot.swift */; };
 		095B47901D47794300880922 /* CurrentTestCaseTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 095B478D1D47794300880922 /* CurrentTestCaseTracker.swift */; };
 		095B47911D47794300880922 /* PrettySyntax.swift in Sources */ = {isa = PBXBuildFile; fileRef = 095B478E1D47794300880922 /* PrettySyntax.swift */; };
@@ -47,8 +45,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				095B47891D47761500880922 /* FBSnapshotTestCase.framework in Frameworks */,
-				095B478A1D47761500880922 /* Nimble.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
When trying to build Nimble-Snapshots for tvOS using Carthage today, the following build errors occur:
```
error: Building for tvOS Simulator, but the linked framework 'FBSnapshotTestCase.framework' was built for iOS + iOS Simulator. (in target 'Nimble_Snapshots' from project 'Nimble_Snapshots')
error: Building for tvOS Simulator, but the linked framework 'Nimble.framework' was built for iOS + iOS Simulator. (in target 'Nimble_Snapshots' from project 'Nimble_Snapshots')
```
This PR fixes the issue by removing the frameworks from the Link Binary With Libraries build phase. I borrowed this approach from [Moya](https://github.com/Moya/Moya).