### PR TITLE
Make Nimble-Snapshots work with Nimble 9.0 and newer

### DIFF
--- a/Nimble-Snapshots.podspec
+++ b/Nimble-Snapshots.podspec
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
                         "Nimble_Snapshots/DynamicType/*.{swift,m,h}",
                         "Nimble_Snapshots/DynamicSize/*.{swift}"
     ss.dependency "iOSSnapshotTestCase", "~> 6.0"
-    ss.dependency "Nimble", "~> 8.0"
+    ss.dependency "Nimble"
   end
 
   # for compatibiliy reasons


### PR DESCRIPTION
This fixes https://github.com/ashfurrow/Nimble-Snapshots/issues/202 so that this gem can work with Xcode 12. 