### PR TITLE
fix conflict with nimble bridging header

### DIFF
--- a/Nimble_Snapshots/CurrentTestCaseTracker.swift
+++ b/Nimble_Snapshots/CurrentTestCaseTracker.swift
@@ -3,7 +3,8 @@ import XCTest
 /// Helper class providing access to the currently executing XCTestCase instance, if any
 @objc
 public final class CurrentTestCaseTracker: NSObject, XCTestObservation {
-    @objc(sharedInstance) public static let shared = CurrentTestCaseTracker()
+    @objc(sharedInstance)
+    public static let shared = CurrentTestCaseTracker()
 
     private(set) var currentTestCase: XCTestCase?
 

--- a/Nimble_Snapshots/CurrentTestCaseTracker.swift
+++ b/Nimble_Snapshots/CurrentTestCaseTracker.swift
@@ -3,7 +3,7 @@ import XCTest
 /// Helper class providing access to the currently executing XCTestCase instance, if any
 @objc
 public final class CurrentTestCaseTracker: NSObject, XCTestObservation {
-    @objc public static let shared = CurrentTestCaseTracker()
+    @objc(sharedInstance) public static let shared = CurrentTestCaseTracker()
 
     private(set) var currentTestCase: XCTestCase?
 

--- a/Nimble_Snapshots/XCTestObservationCenter+CurrentTestCaseTracker.m
+++ b/Nimble_Snapshots/XCTestObservationCenter+CurrentTestCaseTracker.m
@@ -8,7 +8,7 @@
 @implementation XCTestObservationCenter (CurrentTestCaseTracker)
 
 + (void)load {
-    [[self sharedTestObservationCenter] addTestObserver:[CurrentTestCaseTracker shared]];
+    [[self sharedTestObservationCenter] addTestObserver:[CurrentTestCaseTracker sharedInstance]];
 }
 
 @end


### PR DESCRIPTION
Hi!

We're getting this compiler error, where there is a conflict in naming for the shared instance of CurrentTestCaseTracker.

Not sure if I can get around it in some other way, but this solves it for us.

/.../Build/Products/Debug-iphonesimulator/Nimble/Nimble.framework/Headers/Nimble-Swift.h:230:103: 'CurrentTestCaseTracker' has different definitions in different modules; first difference is definition in module 'Nimble.Swift' found property name 'sharedInstance'

/.../Build/Products/Debug-iphonesimulator/Nimble-Snapshots/Nimble_Snapshots.framework/Headers/Nimble_Snapshots-Swift.h:216:103: But in 'Nimble_Snapshots.Swift' found property name 'shared'
