### PR TITLE
Update the tvOS version from 9.0 to 10.0

### DIFF
--- a/Nimble-Snapshots.podspec
+++ b/Nimble-Snapshots.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.author             = { "Ash Furrow" => "ash@ashfurrow.com" }
   s.social_media_url   = "http://twitter.com/ashfurrow"
   s.ios.deployment_target = "10.0"
-  s.tvos.deployment_target = "9.0"
+  s.tvos.deployment_target = "10.0"
   s.swift_version = '5.0'
   s.pod_target_xcconfig = { 'ENABLE_BITCODE' => 'NO' }
   s.source       = { :git => "https://github.com/ashfurrow/Nimble-Snapshots.git", :tag => s.version }


### PR DESCRIPTION
This is necessary because the dependency doesn't compile anymore.

.../Pods/Nimble-Snapshots/Nimble_Snapshots/HaveValidSnapshot.swift:1:8: Compiling for tvOS 9.0, but module 'FBSnapshotTestCase' has a minimum deployment target of tvOS 10.0: ...-bwcvxbxvnwfwrqdcekdprthjvvbq/Build/Products/Testing-appletvsimulator/iOSSnapshotTestCase/FBSnapshotTestCase.framework/Modules/FBSnapshotTestCase.swiftmodule/x86_64-apple-tvos-simulator.swiftmodule