### PR TITLE
Add swift-tools 5.3 package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.4
+// swift-tools-version:5.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription


### PR DESCRIPTION
Downgrade swift-tools package to 5.3, allowing older versions of Xcode to use SPM