### PR TITLE
Moves Danger to end of CI run

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,17 +20,6 @@ jobs:
           ruby-version: 2.7.2
           bundler-cache: true
 
-      - name: Danger action
-        uses: MeilCli/danger-action@v5.4.11
-        if: github.event_name == 'pull_request'
-        with:
-          plugins_file: 'Gemfile'
-          install_path: 'vendor/bundle'
-          danger_file: 'Dangerfile'
-          danger_id: 'danger-pr'
-        env:
-          DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: "Create output dir"
         run: mkdir output
       
@@ -64,4 +53,15 @@ jobs:
         with:
           name: FailureDiffs
           path: |
-            Bootstrap/BootstrapTests/FailureDiffs/            
+            Bootstrap/BootstrapTests/FailureDiffs/        
+
+      - name: Danger action
+        uses: MeilCli/danger-action@v5.4.11
+        if: github.event_name == 'pull_request'
+        with:
+          plugins_file: 'Gemfile'
+          install_path: 'vendor/bundle'
+          danger_file: 'Dangerfile'
+          danger_id: 'danger-pr'
+        env:
+          DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}    


### PR DESCRIPTION
Ran into a problem in #255 where the Danger run prevented tests from being ran at all. This PR moves Danger to the end, which will be faster than trying to get all the tests running locally for me at the moment 😅 