### PR TITLE
Fix building on Xcode 15 by specifying Nimble.Predicate

### DIFF
--- a/Nimble_Snapshots/DynamicSize/DynamicSizeSnapshot.swift
+++ b/Nimble_Snapshots/DynamicSize/DynamicSizeSnapshot.swift
@@ -153,7 +153,7 @@ public func haveValidDynamicSizeSnapshot<T: Snapshotable>(named name: String? = 
                                          pixelTolerance: CGFloat? = nil,
                                          tolerance: CGFloat? = nil,
                                          resizeMode: ResizeMode = .frame,
-                                         shouldIgnoreScale: Bool = false) -> Predicate<T> {
+                                         shouldIgnoreScale: Bool = false) -> Nimble.Predicate<T> {
     return Predicate { actualExpression in
         return performDynamicSizeSnapshotTest(name,
                                               identifier: identifier,
@@ -250,7 +250,7 @@ public func recordDynamicSizeSnapshot<T: Snapshotable>(named name: String? = nil
                                       isDeviceAgnostic: Bool = false,
                                       usesDrawRect: Bool = false,
                                       resizeMode: ResizeMode = .frame,
-                                      shouldIgnoreScale: Bool = false) -> Predicate<T> {
+                                      shouldIgnoreScale: Bool = false) -> Nimble.Predicate<T> {
     return Predicate { actualExpression in
         return performDynamicSizeSnapshotTest(name,
                                               identifier: identifier,

--- a/Nimble_Snapshots/DynamicType/HaveValidDynamicTypeSnapshot.swift
+++ b/Nimble_Snapshots/DynamicType/HaveValidDynamicTypeSnapshot.swift
@@ -15,8 +15,8 @@ func shortCategoryName(_ category: UIContentSizeCategory) -> String {
     return category.rawValue.replacingOccurrences(of: "UICTContentSizeCategory", with: "")
 }
 
-func combinePredicates<T>(_ predicates: [Predicate<T>],
-                          deferred: (() -> Void)? = nil) -> Predicate<T> {
+func combinePredicates<T>(_ predicates: [Nimble.Predicate<T>],
+                          deferred: (() -> Void)? = nil) -> Nimble.Predicate<T> {
     return Predicate { actualExpression in
         defer {
             deferred?()
@@ -37,18 +37,18 @@ public func haveValidDynamicTypeSnapshot<T: Snapshotable>(named name: String? = 
                                          pixelTolerance: CGFloat? = nil,
                                          tolerance: CGFloat? = nil,
                                          sizes: [UIContentSizeCategory] = allContentSizeCategories(),
-                                         isDeviceAgnostic: Bool = false) -> Predicate<T> {
+                                         isDeviceAgnostic: Bool = false) -> Nimble.Predicate<T> {
     let mock = NBSMockedApplication()
 
-    let predicates: [Predicate<T>] = sizes.map { category in
+    let predicates: [Nimble.Predicate<T>] = sizes.map { category in
         let sanitizedName = sanitizedTestName(name)
         let nameWithCategory = "\(sanitizedName)_\(shortCategoryName(category))"
 
-        return Predicate { actualExpression in
+        return Nimble.Predicate { actualExpression in
             mock.mockPreferredContentSizeCategory(category)
             updateTraitCollection(on: actualExpression)
 
-            let predicate: Predicate<T>
+            let predicate: Nimble.Predicate<T>
             if isDeviceAgnostic {
                 predicate = haveValidDeviceAgnosticSnapshot(named: nameWithCategory, identifier: identifier,
                                                             usesDrawRect: usesDrawRect, pixelTolerance: pixelTolerance,
@@ -74,18 +74,18 @@ public func recordDynamicTypeSnapshot<T: Snapshotable>(named name: String? = nil
                                       identifier: String? = nil,
                                       usesDrawRect: Bool = false,
                                       sizes: [UIContentSizeCategory] = allContentSizeCategories(),
-                                      isDeviceAgnostic: Bool = false) -> Predicate<T> {
+                                      isDeviceAgnostic: Bool = false) -> Nimble.Predicate<T> {
     let mock = NBSMockedApplication()
 
-    let predicates: [Predicate<T>] = sizes.map { category in
+    let predicates: [Nimble.Predicate<T>] = sizes.map { category in
         let sanitizedName = sanitizedTestName(name)
         let nameWithCategory = "\(sanitizedName)_\(shortCategoryName(category))"
 
-        return Predicate { actualExpression in
+        return Nimble.Predicate { actualExpression in
             mock.mockPreferredContentSizeCategory(category)
             updateTraitCollection(on: actualExpression)
 
-            let predicate: Predicate<T>
+            let predicate: Nimble.Predicate<T>
             if isDeviceAgnostic {
                 predicate = recordDeviceAgnosticSnapshot(named: nameWithCategory,
                                                          identifier: identifier,

--- a/Nimble_Snapshots/HaveValidSnapshot.swift
+++ b/Nimble_Snapshots/HaveValidSnapshot.swift
@@ -280,7 +280,7 @@ public func haveValidSnapshot<T: Snapshotable>(named name: String? = nil,
                               usesDrawRect: Bool = false,
                               pixelTolerance: CGFloat? = nil,
                               tolerance: CGFloat? = nil,
-                              shouldIgnoreScale: Bool = false) -> Predicate<T> {
+                              shouldIgnoreScale: Bool = false) -> Nimble.Predicate<T> {
 
     return Predicate { actualExpression in
         if switchChecksWithRecords {
@@ -306,7 +306,7 @@ public func haveValidDeviceAgnosticSnapshot<T: Snapshotable>(named name: String?
                                             usesDrawRect: Bool = false,
                                             pixelTolerance: CGFloat? = nil,
                                             tolerance: CGFloat? = nil,
-                                            shouldIgnoreScale: Bool = false) -> Predicate<T> {
+                                            shouldIgnoreScale: Bool = false) -> Nimble.Predicate<T> {
 
     return Predicate { actualExpression in
         if switchChecksWithRecords {
@@ -332,7 +332,7 @@ public func haveValidDeviceAgnosticSnapshot<T: Snapshotable>(named name: String?
 public func recordSnapshot<T: Snapshotable>(named name: String? = nil,
                            identifier: String? = nil,
                            usesDrawRect: Bool = false,
-                           shouldIgnoreScale: Bool = false) -> Predicate<T> {
+                           shouldIgnoreScale: Bool = false) -> Nimble.Predicate<T> {
 
     return Predicate { actualExpression in
         return recordSnapshot(name, identifier: identifier, usesDrawRect: usesDrawRect,
@@ -344,7 +344,7 @@ public func recordSnapshot<T: Snapshotable>(named name: String? = nil,
 public func recordDeviceAgnosticSnapshot<T: Snapshotable>(named name: String? = nil,
                                          identifier: String? = nil,
                                          usesDrawRect: Bool = false,
-                                         shouldIgnoreScale: Bool = false) -> Predicate<T> {
+                                         shouldIgnoreScale: Bool = false) -> Nimble.Predicate<T> {
 
     return Predicate { actualExpression in
         return recordSnapshot(name, identifier: identifier, isDeviceAgnostic: true, usesDrawRect: usesDrawRect,


### PR DESCRIPTION
Foundation in the new betas has a new `Predicate` API which conflicts with Nimble's `Predicate` API. This causes build errors in the current shipping Nimble-Snapshots. This fixes that by specifying `Nimble.Predicate` where there were build errors.