### PR TITLE
Version bump to 9.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 - Nothing yet!
 
+## 9.9.0
+
+- Add SwiftUI support for standard and dynamic type snapshot matchers @dogo
+- Fixes non-deterministic behavior in snapshot tests when using usesDrawRect: true @dogo
+- Fixes deprecated use of SourceLocation.file @paulz
+- Fixes Dynamic Type trait updates and sanitize test artifacts @dogo
+
 ## 9.8.0
 
 - Adds Nimble.Expression to correct Xcode 16 beta build issue. See [#282](https://github.com/ashfurrow/Nimble-Snapshots/pull/282) - @Ripcord715

--- a/Nimble-Snapshots.podspec
+++ b/Nimble-Snapshots.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Nimble-Snapshots"
-  s.version      = "9.8.0"
+  s.version      = "9.9.0"
   s.summary      = "Nimble matchers for iOSSnapshotTestCase"
   s.description  = <<-DESC
                    Nimble matchers for iOSSnapshotTestCase. Highly derivative of [Expecta Matchers for iOSSnapshotTestCase](https://github.com/dblock/ios-snapshot-test-case-expecta).


### PR DESCRIPTION
This pull request prepares for the 9.9.0 release by updating the version and documenting new features and fixes. The most important changes include adding SwiftUI support, fixing snapshot test behavior, and addressing deprecated API usage.

**Release preparation and documentation:**

* Updated the version to 9.9.0 in the Nimble-Snapshots.podspec file.
* Added a changelog entry for version 9.9.0.

@ashfurrow, could you please make this release if you agree? Thanks!
