### PR TITLE
Add recordAllSnapshots() support for DynamicType and DynamicSize

### DIFF
--- a/Nimble_Snapshots/DynamicSize/DynamicSizeSnapshot.swift
+++ b/Nimble_Snapshots/DynamicSize/DynamicSizeSnapshot.swift
@@ -153,7 +153,7 @@ public func haveValidDynamicSizeSnapshot<T: Snapshotable>(named name: String? = 
                                        actualExpression: actualExpression,
                                        tolerance: tolerance,
                                        pixelTolerance: pixelTolerance,
-                                       isRecord: false,
+                                       isRecord: switchChecksWithRecords,
                                        resizeMode: resizeMode,
                                        shouldIgnoreScale: shouldIgnoreScale)
     }

--- a/Nimble_Snapshots/DynamicType/PrettyDynamicTypeSyntax.swift
+++ b/Nimble_Snapshots/DynamicType/PrettyDynamicTypeSyntax.swift
@@ -34,15 +34,16 @@ public func recordDynamicTypeSnapshot(_ name: String? = nil,
 }
 
 public func == (lhs: Nimble.SyncExpectation<Snapshotable>, rhs: DynamicTypeSnapshot) {
+    let shouldRecord = rhs.record || switchChecksWithRecords
     if let name = rhs.name {
-        if rhs.record {
+        if shouldRecord {
             lhs.to(recordDynamicTypeSnapshot(named: name, sizes: rhs.sizes, isDeviceAgnostic: rhs.deviceAgnostic))
         } else {
             lhs.to(haveValidDynamicTypeSnapshot(named: name, sizes: rhs.sizes, isDeviceAgnostic: rhs.deviceAgnostic))
         }
 
     } else {
-        if rhs.record {
+        if shouldRecord {
             lhs.to(recordDynamicTypeSnapshot(sizes: rhs.sizes, isDeviceAgnostic: rhs.deviceAgnostic))
         } else {
             lhs.to(haveValidDynamicTypeSnapshot(sizes: rhs.sizes, isDeviceAgnostic: rhs.deviceAgnostic))
@@ -51,15 +52,16 @@ public func == (lhs: Nimble.SyncExpectation<Snapshotable>, rhs: DynamicTypeSnaps
 }
 
 public func == (lhs: Nimble.AsyncExpectation<Snapshotable>, rhs: DynamicTypeSnapshot) async {
+    let shouldRecord = rhs.record || switchChecksWithRecords
     if let name = rhs.name {
-        if rhs.record {
+        if shouldRecord {
             await lhs.to(recordDynamicTypeSnapshot(named: name, sizes: rhs.sizes, isDeviceAgnostic: rhs.deviceAgnostic))
         } else {
             await lhs.to(haveValidDynamicTypeSnapshot(named: name, sizes: rhs.sizes, isDeviceAgnostic: rhs.deviceAgnostic))
         }
 
     } else {
-        if rhs.record {
+        if shouldRecord {
             await lhs.to(recordDynamicTypeSnapshot(sizes: rhs.sizes, isDeviceAgnostic: rhs.deviceAgnostic))
         } else {
             await lhs.to(haveValidDynamicTypeSnapshot(sizes: rhs.sizes, isDeviceAgnostic: rhs.deviceAgnostic))


### PR DESCRIPTION
This pull request updates snapshot testing behavior to allow global override of recording mode based on the `switchChecksWithRecords` flag. Now, snapshot tests will record new snapshots if either the per-snapshot `record` flag or the global `switchChecksWithRecords` flag is set, making it easier to toggle recording across all tests.

Snapshot recording logic improvements:

* Updated the equality operators for both synchronous and asynchronous dynamic type snapshot expectations to use a new `shouldRecord` variable, which enables recording if either the individual snapshot's `record` flag or the global `switchChecksWithRecords` flag is true. 
* Changed the `haveValidDynamicSizeSnapshot` function to use `switchChecksWithRecords` for the `isRecord` parameter, allowing global control over dynamic size snapshot recording. 